### PR TITLE
Terry/auto detect

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,12 +164,14 @@ command:
 
 Usage:
   ./tools/bl led \
-  	<DEVICE_PATH> \
+  	<DEVICE_PATH|auto|--auto|-a> \
   	<LED_MASK>
 ```
 
 The DEVICE_PATH is the tty device reported in `dmesg` when the device was
-connected.
+connected. When `auto` and friends are provided, it will try to guess the
+tty deivce name based on the `manufactuer` and `product` fields of USB
+devices.
 
 The LED_MASK is a 16-bit mask of the 16 LEDs on the device.  If a bit is
 set, then the corresponding LED is turned on:

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Example: `sudo ./run.sh /dev/ttyACM1`
+# Example: `sudo ./run.sh auto`
 
 declare DEVICE="$1"
 

--- a/src/usb.c
+++ b/src/usb.c
@@ -40,9 +40,9 @@ enum usb_bl_strings {
 };
 
 static const char *bl_usb_strings[] = {
-	[BL_USB_STRING_MANUFACTURER]  = "Codethink",
-	[BL_USB_STRING_PRODUCT]       = "Medical Plethysmograph Device",
-	[BL_USB_STRING_SERIAL_NUMBER] = "ct-mpd:000000",
+	[BL_USB_STRING_MANUFACTURER]  = BL_STR_MANUFACTURER,
+	[BL_USB_STRING_PRODUCT]       = BL_STR_PRODUCT,
+	[BL_USB_STRING_SERIAL_NUMBER] = BL_STR_SERIAL_NUM,
 };
 
 static const struct usb_device_descriptor device_descriptor = {

--- a/src/usb.h
+++ b/src/usb.h
@@ -17,6 +17,10 @@
 #ifndef BL_USB_H
 #define BL_USB_H
 
+#define BL_STR_MANUFACTURER "Codethink"
+#define BL_STR_PRODUCT      "Medical Plethysmograph Device"
+#define BL_STR_SERIAL_NUM   "ct-mpd:000000"
+
 /**
  * Initialise the USB module.
  */

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -7,6 +7,6 @@ clean:
 
 bl: bl.c msg.o find_device.o
 convert: convert.c msg.o
-calibrate: calibrate.c msg.o
+calibrate: calibrate.c msg.o find_device.o
 msg.o: msg.c
 find_device.o: find_device.c

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,11 +1,12 @@
-CFLAGS=-g -O2 -Wall -Wextra -pedantic --std=gnu11
+CFLAGS=-g -O2 -Wall -Wextra -pedantic --std=gnu11 -ludev
 LDFLAGS=-g
 
 all: bl convert calibrate
 clean:
 	rm -f bl convert *.o
 
-bl: bl.c msg.o
+bl: bl.c msg.o find_device.o
 convert: convert.c msg.o
 calibrate: calibrate.c msg.o
 msg.o: msg.c
+find_device.o: find_device.c

--- a/tools/bl.c
+++ b/tools/bl.c
@@ -286,7 +286,7 @@ static int bl_cmd_led(int argc, char *argv[])
 	if (argc != ARG__COUNT) {
 		fprintf(stderr, "Usage:\n");
 		fprintf(stderr, "  %s %s \\\n"
-				"  \t<DEVICE_PATH> \\\n"
+				"  \t<DEVICE_PATH|auto|--auto|-a> \\\n"
 				"  \t<LED_MASK>\n",
 				argv[ARG_PROG],
 				argv[ARG_CMD]);
@@ -349,7 +349,7 @@ static int bl_cmd_channel_conf(int argc, char *argv[])
 	if (argc < (ARG_OFFSET) || argc > ARG__COUNT) {
 		fprintf(stderr, "Usage:\n");
 		fprintf(stderr, "  %s %s \\\n"
-				"  \t<DEVICE_PATH> \\\n"
+				"  \t<DEVICE_PATH|auto|--auto|-a> \\\n"
 				"  \t<CHANNEL> \\\n"
 				"  \t<GAIN> \\\n"
 				"  \t[OFFSET] \\\n"
@@ -450,7 +450,7 @@ static int bl_cmd__no_params_helper(
 
 	if (argc != ARG__COUNT) {
 		fprintf(stderr, "Usage:\n");
-		fprintf(stderr, "  %s %s <DEVICE_PATH>\n",
+		fprintf(stderr, "  %s %s <DEVICE_PATH|auto|--auto|-a>\n",
 				argv[ARG_PROG], argv[ARG_CMD]);
 		return EXIT_FAILURE;
 	}
@@ -511,7 +511,7 @@ static int bl_cmd_start_stream(
 	if (argc != ARG__COUNT) {
 		fprintf(stderr, "Usage:\n");
 		fprintf(stderr, "  %s %s \\\n"
-				"  \t<DEVICE_PATH> \\\n"
+				"  \t<DEVICE_PATH|auto|--auto|-a> \\\n"
 				"  \t<FREQUENCY> \\\n"
 				"  \t<OVERSAMPLE> \\\n"
 				"  \t<SRC_MASK>\n",

--- a/tools/bl.c
+++ b/tools/bl.c
@@ -36,6 +36,7 @@
 /* Common helper functionality. */
 #include "msg.h"
 #include "find_device.h"
+
 /* Whether we've had a `ctrl-c`. */
 volatile bool killed;
 
@@ -679,55 +680,24 @@ static int bl_setup_signal_handler(void)
 	return EXIT_SUCCESS;
 }
 
-static void bl_auto_dev(char *argv[])
-{
-	enum
-	{
-		ARG_PROG,
-		ARG_CMD,
-		ARG_DEV_PATH,
-		ARG__COUNT,
-	};
-
-	if ((strncmp(argv[ARG_DEV_PATH], "auto", 4) ||
-		 strncmp(argv[ARG_DEV_PATH], "--auto", 6) ||
-		 strncmp(argv[ARG_DEV_PATH], "-a", 2)))
-	{
-		int found = scan();
-		switch (found)
-		{
-		case 0:
-			fprintf(stderr, "No MPD device found.\n");
-			exit(EXIT_FAILURE);
-		case 1:
-			printf("valid device at: %s\n", dev_node);
-			argv[ARG_DEV_PATH] = dev_node;
-			break;
-		default:
-			fprintf(stderr, "More than one device found, please specify which device to use.\n");
-			bl_cmd_help(argv[ARG_PROG]);
-			exit(EXIT_FAILURE);
-		}
-	}
-}
-
 int main(int argc, char *argv[])
 {
 	bl_cmd_fn cmd_fn;
 	enum {
 		ARG_PROG,
 		ARG_CMD,
+		ARG_DEV_PATH,
 		ARG__COUNT,
 	};
 
-	if (argc < ARG__COUNT) {
+	if (argc < ARG_DEV_PATH) {
 		bl_cmd_help(argv[ARG_PROG]);
 		return EXIT_FAILURE;
 	}
 
 	/* All valid comments using device path have more than 2 arguments */
-	if (argc > ARG__COUNT)
-		bl_auto_dev(argv);
+	if (argc > ARG_DEV_PATH)
+		get_dev(ARG_DEV_PATH, argv);
 
 	cmd_fn = bl_cmd_lookup(argv[ARG_CMD]);
 	if (cmd_fn == NULL) {

--- a/tools/calibrate.c
+++ b/tools/calibrate.c
@@ -31,6 +31,7 @@
 
 /* Common helper functionality. */
 #include "msg.h"
+#include "find_device.h"
 
 /** Whether we've had a `ctrl-c`. */
 volatile bool killed;
@@ -167,7 +168,7 @@ static int bl__calibrate(const char *dev_path)
 static void bl__help(const char *prog)
 {
 	fprintf(stderr, "Usage:\n");
-	fprintf(stderr, "  %s DEV_PATH\n", prog);
+	fprintf(stderr, "  %s <DEV_PATH|auto|--auto|-a>\n", prog);
 	fprintf(stderr, "\n");
 	fprintf(stderr, "Reads an aqcuisition log message from stdin, and prints\n");
 	fprintf(stderr, "suggested acquisition parameters to stdout\n");
@@ -227,6 +228,8 @@ int main(int argc, char *argv[])
 	if (bl__setup_signal_handler() != EXIT_SUCCESS) {
 		return EXIT_FAILURE;
 	}
+
+	get_dev(ARG_DEV_PATH, argv);
 
 	return bl__calibrate(argv[ARG_DEV_PATH]);
 }

--- a/tools/find_device.c
+++ b/tools/find_device.c
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include <stdbool.h>
 
+#include "../src/usb.h"
 #include "find_device.h"
 
 /* Valid Codethink Medical Plethysmograph Device path */
@@ -104,9 +105,9 @@ static bool match(char *sysname)
 	 encoded, but the strings returned from
 	 udev_device_get_sysattr_value() are UTF-8 encoded. */
 	if (!strncmp(udev_device_get_sysattr_value(dev, "manufacturer"),
-				 "Codethink", 9) &&
+				 BL_STR_MANUFACTURER, 9) &&
 		!strncmp(udev_device_get_sysattr_value(dev, "product"),
-				 "Medical Plethysmograph Device", 29))
+				 BL_STR_PRODUCT, 29))
 		return true;
 
 dev_out:

--- a/tools/find_device.c
+++ b/tools/find_device.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <libudev.h>
+#include <locale.h>
+#include <unistd.h>
+#include <stdbool.h>
+
+#include "find_device.h"
+
+/* Valid Codethink Medical Plethysmograph Device path */
+char dev_node[32];
+
+static bool match(char *sysname)
+{
+	struct udev *udev;
+	struct udev_enumerate *enumerate;
+	struct udev_list_entry *device;
+	struct udev_device *dev;
+	const char *path;
+
+	/* Create the udev object */
+	udev = udev_new();
+	if (!udev)
+	{
+		fprintf(stderr, "Can't create udev\n");
+		goto out;
+	}
+
+	/* Create a list of the devices with the name "ttyACM*". */
+	enumerate = udev_enumerate_new(udev);
+	if (!enumerate)
+	{
+		fprintf(stderr, "Can't create udev enumerate context.\n");
+		goto udev_out;
+	}
+
+	if (udev_enumerate_add_match_sysname(enumerate, sysname) < 0)
+	{
+		fprintf(stderr, "Failed on adding udev enumerate filter.\n");
+		goto enum_out;
+	}
+
+	if (udev_enumerate_scan_devices(enumerate) < 0)
+	{
+		fprintf(stderr, "Failed on scanning device.\n");
+		goto enum_out;
+	}
+
+
+	/* udev_enumerate_get_list_entry returns a list of entry,
+	but we only need the first entry, because we only cares
+	about their parent which are the same for all. */
+	device = udev_enumerate_get_list_entry(enumerate);
+
+
+	/* Get the filename of the /sys entry for the device
+	 and create a udev_device object (dev) representing it */
+	path = udev_list_entry_get_name(device);
+	if (!path)
+	{
+		printf("No matched device found.\n");
+		goto enum_out;
+	}
+	dev = udev_device_new_from_syspath(udev, path);
+
+	/* In order to get information about the
+	 USB device, get the parent device with the
+	 subsystem/devtype pair of "usb"/"usb_device". This will
+	 be several levels up the tree, but the function will find
+	 it.*/
+	dev = udev_device_get_parent_with_subsystem_devtype(
+		dev,
+		"usb",
+		"usb_device");
+	if (!dev)
+	{
+		fprintf(stderr, "Unable to find parent usb device.");
+		goto dev_out;
+	}
+
+	/* From here, we can call get_sysattr_value() for each file
+	 in the device's /sys entry. The strings passed into these
+	 functions (idProduct, idVendor, serial, etc.) correspond
+	 directly to the files in the directory which represents
+	 the USB device. Note that USB strings are Unicode, UCS2
+	 encoded, but the strings returned from
+	 udev_device_get_sysattr_value() are UTF-8 encoded. */
+	if (!strncmp(udev_device_get_sysattr_value(dev, "manufacturer"),
+				 "Codethink", 9) &&
+		!strncmp(udev_device_get_sysattr_value(dev, "product"),
+				 "Medical Plethysmograph Device", 29))
+		return true;
+
+dev_out:
+	udev_device_unref(dev);
+enum_out:
+	/* Free the enumerator object */
+	udev_enumerate_unref(enumerate);
+udev_out:
+	udev_unref(udev);
+out:
+	return false;
+}
+
+/* filter function for /dev nodes match */
+static int dev_match(const struct dirent *entry)
+{
+	return !strncmp(entry->d_name, "ttyACM", 6);
+}
+
+int scan(void)
+{
+	struct dirent **namelist;
+	int n, found = 0;
+
+	n = scandir("/dev/", &namelist, dev_match, NULL);
+	if (n == -1)
+	{
+		fprintf(stderr, "scandir fails\n");
+		exit(EXIT_FAILURE);
+	}
+
+	while (n--)
+	{
+		if (match(namelist[n]->d_name))
+		{
+			int ret = snprintf(dev_node, sizeof(dev_node) - 1,
+							   "/dev/%s", namelist[n]->d_name);
+			if (ret < 0 || ret >= sizeof(dev_node) - 1)
+			{
+				fprintf(stderr, "Error on saving device path: %s\n",
+						namelist[n]->d_name);
+
+				free(namelist[n]);
+				break;
+			}
+			found++;
+		}
+		free(namelist[n]);
+	}
+	free(namelist);
+
+	return found;
+}
+
+int main(void)
+{
+	int found = scan();
+	switch (found)
+	{
+	case 0:
+		printf("no device found");
+		break;
+	case 1:
+		printf("valid device at: %s\n", dev_node);
+		break;
+	default:
+		printf("more than one device found, please specify which device to use.\n");
+	}
+	exit(EXIT_SUCCESS);
+}

--- a/tools/find_device.c
+++ b/tools/find_device.c
@@ -161,6 +161,7 @@ int scan(void)
 	return found;
 }
 
+/*
 int main(void)
 {
 	int found = scan();
@@ -177,3 +178,4 @@ int main(void)
 	}
 	exit(EXIT_SUCCESS);
 }
+*/

--- a/tools/find_device.c
+++ b/tools/find_device.c
@@ -127,7 +127,7 @@ static int dev_match(const struct dirent *entry)
 	return !strncmp(entry->d_name, "ttyACM", 6);
 }
 
-int scan(void)
+static int scan(void)
 {
 	struct dirent **namelist;
 	int n, found = 0;
@@ -145,7 +145,7 @@ int scan(void)
 		{
 			int ret = snprintf(dev_node, sizeof(dev_node) - 1,
 							   "/dev/%s", namelist[n]->d_name);
-			if (ret < 0 || ret >= sizeof(dev_node) - 1)
+			if (ret < 0 || ret >= (int)(sizeof(dev_node) - 1))
 			{
 				fprintf(stderr, "Error on saving device path: %s\n",
 						namelist[n]->d_name);
@@ -160,6 +160,28 @@ int scan(void)
 	free(namelist);
 
 	return found;
+}
+
+void get_dev(int dev, char *argv[])
+{
+    if ((strncmp(argv[dev], "auto", 4) ||
+         strncmp(argv[dev], "--auto", 6) ||
+         strncmp(argv[dev], "-a", 2)))
+    {
+        int found = scan();
+        switch (found)
+        {
+        case 0:
+            fprintf(stderr, "No MPD device found.\n");
+            exit(EXIT_FAILURE);
+        case 1:
+            argv[dev] = dev_node;
+            break;
+        default:
+            fprintf(stderr, "More than one device found, please specify which device to use.\n");
+            exit(EXIT_FAILURE);
+        }
+    }
 }
 
 /*

--- a/tools/find_device.h
+++ b/tools/find_device.h
@@ -1,0 +1,14 @@
+#ifndef BL_TOOLS_FIND_DEVICE_H
+#define Bl_TOOLS_FIND_DEVICE_H
+
+/* The path name of the matched /dev node */
+extern char dev_node[32];
+
+/**
+ * Scan the /dev nodes and match the right ACM devices
+ *
+ * Return: number of matched devices
+ */
+int scan(void);
+
+#endif /* BL_TOOLS_FIND_DEVICE_H */

--- a/tools/find_device.h
+++ b/tools/find_device.h
@@ -5,10 +5,13 @@
 extern char dev_node[32];
 
 /**
- * Scan the /dev nodes and match the right ACM devices
+ * Get the /dev nodes that matches the right ACM devices
  *
- * Return: number of matched devices
+ * If a device node is provided from command line, it will
+ * be used, otherwise, program will try to match the product
+ * and manufacturer fields of USB device to guess the best
+ * device node to use.
  */
-int scan(void);
+extern void get_dev(int dev, char *argv[]);
 
 #endif /* BL_TOOLS_FIND_DEVICE_H */


### PR DESCRIPTION
This patch set add the option to automatically detect the ttyACM device name for the Medical  Plethysmograph Device manufactured by Codethink and use it if it's unique.

To use this option, you have to pass `auto` or `--auto` or `-a` in the command line