### PR TITLE
Use CRS for USB clocking on revision 2

### DIFF
--- a/src/bl.c
+++ b/src/bl.c
@@ -50,7 +50,7 @@ void bl_init(void)
 #if (BL_REVISION == 1)
 	rcc_config = &rcc_hse_16mhz_3v3;
 #else
-	rcc_config = &rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_96MHZ];
+	rcc_config = &rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_170MHZ];
 
 	rcc_periph_clock_enable(RCC_PWR);
 	rcc_periph_clock_enable(RCC_FLASH);


### PR DESCRIPTION
Use CRS for USB on revision 2 so we can clock at the full 170MHz.