### PR TITLE
Write a tool to normalise incoming samples

### DIFF
--- a/src/msg.h
+++ b/src/msg.h
@@ -19,6 +19,7 @@
 
 #include "acq.h"
 #include "led.h"
+#include <inttypes.h>
 #include <stddef.h>
 
 /**

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,7 +5,7 @@ all: bl convert calibrate
 clean:
 	rm -f bl convert calibrate *.o
 
-bl: bl.c msg.o device.o sig.o
+bl: bl.c msg.o device.o sig.o util.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 convert: convert.c msg.o sig.o fifo.o

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -8,7 +8,7 @@ clean:
 bl: bl.c msg.o device.o sig.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
-convert: convert.c msg.o sig.o
+convert: convert.c msg.o sig.o fifo.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 calibrate: calibrate.c msg.o sig.o

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,7 +1,7 @@
 CFLAGS=-g -O2 -Wall -Wextra -pedantic --std=gnu11
 LDFLAGS=-g -ludev
 
-all: bl convert calibrate
+all: bl convert calibrate normalize
 clean:
 	rm -f bl convert calibrate *.o
 
@@ -13,3 +13,6 @@ convert: convert.c msg.o sig.o fifo.o
 
 calibrate: calibrate.c msg.o sig.o
 	$(CC) -o $@ $^ $(LDFLAGS)
+
+normalize: normalize.c msg.o sig.o fifo.o util.o
+	$(CC) -o $@ $^ $(CFLAGS) $(LDFLAGS)

--- a/tools/bl.c
+++ b/tools/bl.c
@@ -16,7 +16,6 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
-#include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -30,46 +29,9 @@
 #include "device.h"
 #include "msg.h"
 #include "sig.h"
+#include "util.h"
 
 typedef int (* bl_cmd_fn)(int argc, char *argv[]);
-
-static inline bool check_fit(uint32_t value, size_t target_size)
-{
-	uint32_t target_max;
-
-	assert(target_size <= 4);
-
-	target_max = (~(uint32_t)0) >> ((sizeof(uint32_t) - target_size) * 8);
-
-	if (value > target_max) {
-		return false;
-	}
-
-	return true;
-}
-
-static inline bool read_sized_uint(
-		const char *value,
-		uint32_t *out,
-		size_t target_size)
-{
-	unsigned long long temp;
-	char *end = NULL;
-
-	errno = 0;
-	temp = strtoull(value, &end, 0);
-
-	if (end == value || errno == ERANGE || temp > UINT32_MAX) {
-		return false;
-	}
-
-	if (!check_fit(temp, target_size)) {
-		return false;
-	}
-
-	*out = (uint32_t)temp;
-	return true;
-}
 
 int bl_cmd_read_and_print_message(int dev_fd, int timeout_ms)
 {

--- a/tools/fifo.c
+++ b/tools/fifo.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+
+#include "fifo.h"
+
+struct fifo *fifo_create(uint16_t capacity)
+{
+	struct fifo *fifo = calloc(1, sizeof(*fifo));
+	if (fifo == NULL) {
+		return NULL;
+	}
+	fifo->values = malloc(capacity * sizeof(*fifo->values));
+	if (fifo->values == NULL) {
+		free(fifo);
+		return NULL;
+	}
+	fifo->capacity = capacity;
+	return fifo;
+}
+
+void fifo_destroy(struct fifo *fifo)
+{
+	free(fifo->values);
+	free(fifo);
+}
+
+static inline uint16_t fifo_advance(const struct fifo *fifo, uint16_t pos)
+{
+	pos++;
+	return (pos >= fifo->capacity) ? 0 : pos;
+}
+
+static uint16_t fifo_seek(const struct fifo *fifo, int32_t pos, int32_t steps)
+{
+	pos += steps;
+	while (pos >= fifo->capacity) {
+		pos -= fifo->capacity;
+	}
+	while (pos < 0) {
+		pos += fifo->capacity;
+	}
+	return pos;
+}
+
+// Returns the nth previously added element from the fifo
+bool fifo_peek_back(const struct fifo *fifo, uint16_t steps, uint32_t *out)
+{
+	if (fifo->used < steps) {
+		// Can't peek back further than we've written
+		return false;
+	}
+
+	*out = fifo->values[fifo_seek(fifo, fifo->read, -steps)];
+	return true;
+}
+
+bool fifo_write(struct fifo *fifo, uint32_t value)
+{
+	if (fifo->used == fifo->capacity) {
+		return false;
+	}
+
+	fifo->values[fifo->read] = value;
+	fifo->read = fifo_advance(fifo, fifo->read);
+	fifo->used++;
+
+	return true;
+}
+
+bool fifo_read(struct fifo *fifo, uint32_t *value)
+{
+	if (fifo->used == 0) {
+		return false;
+	}
+
+	*value = fifo->values[fifo->write];
+	fifo->write = fifo_advance(fifo, fifo->write);
+	fifo->used--;
+
+	return true;
+}

--- a/tools/fifo.h
+++ b/tools/fifo.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <inttypes.h>
+#include <stdbool.h>
+
+struct fifo {
+	uint32_t *values;
+	uint16_t capacity;
+	uint16_t write;
+	uint16_t read;
+	uint16_t used;
+};
+
+struct fifo *fifo_create(uint16_t capacity);
+void fifo_destroy(struct fifo *fifo);
+bool fifo_peek_back(const struct fifo *fifo, uint16_t steps, uint32_t *out);
+bool fifo_write(struct fifo *fifo, uint32_t value);
+bool fifo_read(struct fifo *fifo, uint32_t *value);

--- a/tools/msg.h
+++ b/tools/msg.h
@@ -1,6 +1,8 @@
 #ifndef BL_TOOLS_MSG_H
 #define BL_TOOLS_MSG_H
 
+#include <stdbool.h>
+
 /**
  * Parse from given file stream into given message data structure.
  *

--- a/tools/normalize.c
+++ b/tools/normalize.c
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <string.h>
+
+#include "../src/msg.h"
+
+#include "msg.h"
+#include "sig.h"
+#include "fifo.h"
+#include "util.h"
+
+// DEFAULT_AVERAGE_WIDTH, the number of milliseconds to average over
+long DEFAULT_AVERAGE_WIDTH = 1000;
+
+struct channel_data {
+	bl_msg_sample_data_t msg; // message to buffer output
+	struct fifo *samples; // all the samples in the rolling sum
+	uint64_t rolling_sum; // sum across the samples that will be averaged
+	uint32_t baseline; // "zero" level for an "average" sample
+};
+
+void add_normalized_sample(bl_msg_sample_data_t *msg, uint32_t sample)
+{
+	// sample may be 16-bit or 32-bit, depending on data format.
+	if (msg->type == BL_MSG_SAMPLE_DATA16) {
+		msg->data16[msg->count] = (uint16_t) sample;
+		msg->count++;
+	} else {
+		msg->data32[msg->count] = sample;
+		msg->count++;
+	}
+	if ((msg->type == BL_MSG_SAMPLE_DATA16
+	     && msg->count == MSG_SAMPLE_DATA16_MAX)
+	    || (msg->type == BL_MSG_SAMPLE_DATA32
+	        && msg->count == MSG_SAMPLE_DATA32_MAX)) {
+			// Message is full, send and start refilling
+			bl_msg_yaml_print(stdout, (union bl_msg_data *) msg);
+			msg->count = 0;
+	}
+}
+
+int add_sample(long average_width,
+		struct channel_data *channel,
+		uint32_t sample)
+{
+	// Add a sample to the fifo
+	if (!fifo_write(channel->samples, sample)) {
+		fprintf(stderr, "FIFO overflow\n");
+		return -ERANGE;
+	}
+	// Add to the rolling sum
+	channel->rolling_sum += sample;
+	if (channel->samples->used >= average_width) {
+		uint32_t new_sample, old_sample;
+		uint32_t normalized_sample;
+
+		// Calculate the normalized sample
+	   	if (!fifo_peek_back(channel->samples,
+					average_width / 2,
+					&new_sample)) {
+			fprintf(stderr, "FIFO underflow\n");
+			return -ERANGE;
+		}
+		normalized_sample = channel->baseline + new_sample
+		                    - (channel->rolling_sum / average_width);
+		add_normalized_sample(&channel->msg, (uint32_t) normalized_sample);
+
+		// Subtract from the rolling sum
+		if (!fifo_read(channel->samples, &old_sample)) {
+			fprintf(stderr, "Tried to read from empty FIFO\n");
+			return -ENOENT;
+		}
+		channel->rolling_sum -= old_sample;
+	}
+	return 0;
+	
+}
+
+void init_channel(struct channel_data *channel,
+		const bl_msg_channel_conf_t *msg)
+{
+	memset(channel, 0, sizeof(*channel));
+	if (msg->sample32) {
+		channel->msg.type = BL_MSG_SAMPLE_DATA32;
+		channel->baseline = INT32_MAX;
+	} else {
+		channel->msg.type = BL_MSG_SAMPLE_DATA16;
+		channel->baseline = INT16_MAX;
+	}
+	channel->msg.channel = msg->channel;
+
+}
+
+void destroy_channel(struct channel_data *channel)
+{
+	fifo_destroy(channel->samples);
+}
+
+int read_stream(FILE *stream, long average_width)
+{
+	union bl_msg_data msg; // message for reading into
+	struct channel_data channels[BL_ACQ__SRC_COUNT]; //One per possible channel
+	struct channel_data *channel;
+	long average_width_samples = 0; // Average width measured in samples
+	while (!bl_sig_killed && bl_msg_yaml_parse(stream, &msg)) {
+		switch(msg.type) {
+		case BL_MSG_CHANNEL_CONF:
+			/* Doesn't create the channel's fifos yet, since we don't know how
+			 * many samples we need to store until we know the frequency */
+			init_channel(channels + msg.channel_conf.channel,
+					&msg.channel_conf);
+			bl_msg_yaml_print(stdout, &msg);
+			break;
+		case BL_MSG_START:
+			average_width_samples = average_width * msg.start.frequency
+				/ 1000; // Magical 1000 from being measured in milliseconds.
+
+			// Create all the channels' fifos now
+			for (unsigned i = 0; i < BL_ACQ__SRC_COUNT; i++) {
+				channels[i].samples = fifo_create(average_width_samples);
+				if (channels[i].samples == NULL) {
+					return -errno;
+				}
+			}
+			bl_msg_yaml_print(stdout, &msg);
+			break;
+		case BL_MSG_SAMPLE_DATA16:
+		case BL_MSG_SAMPLE_DATA32:
+			channel = channels + msg.sample_data.channel;
+
+			if (channel->msg.type != msg.type) {
+				fprintf(stderr,
+					"Error: Sample data for channel %"PRIu8" has an unexpected"
+					" type (expected %d, got %d)\n", msg.sample_data.channel,
+					channel->msg.type, msg.type);
+				return -1;
+			}
+
+			for (unsigned i = 0; i < msg.sample_data.count; i++) {
+				int ret;
+				if (msg.type == BL_MSG_SAMPLE_DATA16) {
+					ret = add_sample(average_width_samples, channel,
+							msg.sample_data.data16[i]);
+				} else {
+					ret = add_sample(average_width_samples, channel,
+							msg.sample_data.data32[i]);
+				}
+				if (ret < 0) {
+					return ret;
+				}
+			}
+			break;
+		default:
+			bl_msg_yaml_print(stdout, &msg);
+		}
+	}
+	for (unsigned i = 0; i < BL_ACQ__SRC_COUNT; i++) {
+		fifo_destroy(channels[i].samples);
+	}
+	return 0;
+}
+
+void usage(FILE* file, char *argv[])
+{
+	fprintf(file, "Usage: %s [AVERAGE_WIDTH]\n", argv[0]);
+	fprintf(file, "  AVERAGE_WIDTH: The time (in ms) to average over\n");
+}
+
+int main(int argc, char *argv[])
+{
+	uint32_t average_width = DEFAULT_AVERAGE_WIDTH;
+	enum {
+		ARG_PROG_NAME,
+		ARG_AVERAGE_WIDTH,
+
+		ARG__COUNT,
+	};
+	/* Reads from stdin, writes to stdout */
+	/* The only argument is averaging width, which has a default */
+	if (argc > ARG__COUNT) {
+		fprintf(stderr, "%d is the wrong number of arguments\n", argc);
+		usage(stderr, argv);
+		return EXIT_FAILURE;
+	}
+
+	// Parse average_width
+	if (argc == ARG__COUNT) {
+		if (read_sized_uint(argv[1], &average_width, sizeof(average_width))) {
+		} else {
+			fprintf(stderr, "Could not parse '%s'\n", argv[ARG_AVERAGE_WIDTH]);
+			usage(stderr, argv);
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (!bl_sig_init()) {
+		return EXIT_FAILURE;
+	}
+
+	return read_stream(stdin, average_width);
+}

--- a/tools/sig.h
+++ b/tools/sig.h
@@ -1,6 +1,8 @@
 #ifndef BL_TOOLS_SIG_H
 #define BL_TOOLS_SIG_H
 
+#include <stdbool.h>
+
 extern volatile bool bl_sig_killed;
 
 /**

--- a/tools/util.c
+++ b/tools/util.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+
+#include "util.h"
+
+static inline bool check_fit(uint32_t value, size_t target_size)
+{
+	uint32_t target_max;
+
+	assert(target_size <= 4);
+
+	target_max = (~(uint32_t)0) >> ((sizeof(uint32_t) - target_size) * 8);
+
+	if (value > target_max) {
+		return false;
+	}
+
+	return true;
+}
+
+bool read_sized_uint(const char *value, uint32_t *out, size_t target_size)
+{
+	unsigned long long temp;
+	char *end = NULL;
+
+	errno = 0;
+	temp = strtoull(value, &end, 0);
+
+	if (end == value || errno == ERANGE || temp > UINT32_MAX) {
+		return false;
+	}
+
+	if (!check_fit(temp, target_size)) {
+		return false;
+	}
+
+	*out = (uint32_t)temp;
+	return true;
+}

--- a/tools/util.h
+++ b/tools/util.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdbool.h>
+#include <inttypes.h>
+
+bool read_sized_uint(const char *value, uint32_t *out, size_t target_size);


### PR DESCRIPTION
"normalise" in this case means flattening out the long-running trend
line in the signal (similar to using a high-pass filter, which at
default is like cutting off any frequencies lower than 0.5Hz).
This is done by:

* Defining a period to average over (default 2 seconds)
* Dividing the current sample by its rolling average over that period.
* Setting the "baseline" (half-way between maximum and minimum) at when
  the current sample is equal to its rolling average.

It's been a while since I last programmed in C, so I'd appreciate code review to suggest what I should improve.

To try this out using your favourite readings yaml, I recommend `./normalize <readings.yaml | ./convert wav out.wav && audacity out.wav`