### PR TITLE
Add Bloodview: Data aqcuisition and live view

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,12 +14,18 @@ jobs:
                make
                clang
                libudev-dev
+               libsdl2-dev
+               libsdl2-ttf-dev
                gcc-arm-none-eabi
                libnewlib-arm-none-eabi
     - name: Build libopencm3
       run: make -j4 -C libopencm3
     - name: Build firmware
       run: make
+    - name: Build bloodview (gcc)
+      run: make -BC bloodview
+    - name: Build bloodview (clang)
+      run: CC=clang make -BC bloodview
     - name: Build tools (gcc)
       run: make -BC tools
     - name: Build tools (clang)
@@ -37,10 +43,16 @@ jobs:
                shellcheck
                clang-tools
                libudev-dev
+               libsdl2-dev
+               libsdl2-ttf-dev
     - name: Shellcheck
       run: shellcheck run.sh
+    - name: Clang scan-build bloodview
+      run: scan-build make -BC bloodview
     - name: Clang scan-build tools
       run: scan-build make -BC tools
+    - name: Cppcheck bloodview
+      run: cppcheck --enable=warning,performance,portability,information --std=c11 bloodview/
     - name: Cppcheck tools
       run: cppcheck --enable=warning,performance,portability,information --std=c11 tools/
     - name: Cppcheck firmware

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ tools/bl
 tools/*.o
 tools/convert
 tools/calibrate
+tools/normalize
 .vscode/
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ And the Bloodlight host tools:
 make -C tools/
 ```
 
+To make the [Bloodview](bloodview/) live-view and control application, run:
+
+```bash
+make -BC bloodview/ run
+```
+
 Installation
 ------------
 

--- a/bloodview/.gitignore
+++ b/bloodview/.gitignore
@@ -1,0 +1,4 @@
+bloodview
+build/
+*-acq.yaml
+*-cal.yaml

--- a/bloodview/Makefile
+++ b/bloodview/Makefile
@@ -11,8 +11,9 @@ LDFLAGS += $(shell pkg-config sdl2 SDL2_ttf --libs)
 ifeq ($(VARIANT), release)
 	CFLAGS += -O2 -DNDEBUG
 else
-	CFLAGS += -O0 -g
-	LDFLAGS += -g
+	CFLAGS += -O0 -g -fsanitize=address -fsanitize=undefined -fno-sanitize-recover
+	LDFLAGS += -g -fsanitize=address -fsanitize=undefined -fno-sanitize-recover
+	BLOODVIEW_ENV += LSAN_OPTIONS=suppressions=resources/lsan-suppr:print_suppressions=0
 endif
 
 MKDIR =	mkdir -p
@@ -41,4 +42,4 @@ $(BV_OBJ): $(BUILDDIR)/%.o : %.c
 
 # We need to run with sudo to open the device.
 run: bloodview
-	@sudo ./bloodview
+	@sudo $(BLOODVIEW_ENV) ./bloodview

--- a/bloodview/Makefile
+++ b/bloodview/Makefile
@@ -2,8 +2,11 @@ VARIANT = release
 
 BUILDDIR = build/$(VARIANT)
 
-CFLAGS = -Wall -Wextra -pedantic --std=gnu11
+CFLAGS = -Wall -Wextra -pedantic --std=gnu11 -Isdl-tk/include
 LDFLAGS = -pthread
+
+CFLAGS += $(shell pkg-config sdl2 SDL2_ttf --cflags)
+LDFLAGS += $(shell pkg-config sdl2 SDL2_ttf --libs)
 
 ifeq ($(VARIANT), release)
 	CFLAGS += -O2 -DNDEBUG
@@ -15,7 +18,8 @@ endif
 MKDIR =	mkdir -p
 
 BV_SRC = \
-	src/bloodview.c
+	src/bloodview.c \
+	src/main-menu.c
 
 BV_OBJ = $(patsubst %.c,%.o, $(addprefix $(BUILDDIR)/,$(BV_SRC)))
 
@@ -27,7 +31,7 @@ clean:
 sdl-tk/sdl-tk.a:
 	make -BC sdl-tk VARIANT=$(VARIANT)
 
-bloodview: $(BV_OBJ)
+bloodview: $(BV_OBJ) sdl-tk/sdl-tk.a
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 $(BV_OBJ): $(BUILDDIR)/%.o : %.c

--- a/bloodview/Makefile
+++ b/bloodview/Makefile
@@ -21,6 +21,7 @@ MKDIR =	mkdir -p
 BV_SRC = \
 	src/bloodview.c \
 	src/main-menu.c \
+	src/data-avg.c \
 	src/sdl.c
 
 BV_OBJ = $(patsubst %.c,%.o, $(addprefix $(BUILDDIR)/,$(BV_SRC)))

--- a/bloodview/Makefile
+++ b/bloodview/Makefile
@@ -23,6 +23,7 @@ BV_SRC = \
 	src/main-menu.c \
 	src/data-avg.c \
 	src/graph.c \
+	src/data.c \
 	src/sdl.c
 
 BV_OBJ = $(patsubst %.c,%.o, $(addprefix $(BUILDDIR)/,$(BV_SRC)))

--- a/bloodview/Makefile
+++ b/bloodview/Makefile
@@ -22,6 +22,7 @@ BV_SRC = \
 	src/bloodview.c \
 	src/main-menu.c \
 	src/data-avg.c \
+	src/graph.c \
 	src/sdl.c
 
 BV_OBJ = $(patsubst %.c,%.o, $(addprefix $(BUILDDIR)/,$(BV_SRC)))

--- a/bloodview/Makefile
+++ b/bloodview/Makefile
@@ -1,0 +1,39 @@
+VARIANT = release
+
+BUILDDIR = build/$(VARIANT)
+
+CFLAGS = -Wall -Wextra -pedantic --std=gnu11
+LDFLAGS = -pthread
+
+ifeq ($(VARIANT), release)
+	CFLAGS += -O2 -DNDEBUG
+else
+	CFLAGS += -O0 -g
+	LDFLAGS += -g
+endif
+
+MKDIR =	mkdir -p
+
+BV_SRC = \
+	src/bloodview.c
+
+BV_OBJ = $(patsubst %.c,%.o, $(addprefix $(BUILDDIR)/,$(BV_SRC)))
+
+all: bloodview
+clean:
+	rm -rf build bloodview
+	make -C sdl-tk clean
+
+sdl-tk/sdl-tk.a:
+	make -BC sdl-tk VARIANT=$(VARIANT)
+
+bloodview: $(BV_OBJ)
+	$(CC) -o $@ $^ $(LDFLAGS)
+
+$(BV_OBJ): $(BUILDDIR)/%.o : %.c
+	@$(MKDIR) $(BUILDDIR)/src
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+# We need to run with sudo to open the device.
+run: bloodview
+	@sudo ./bloodview

--- a/bloodview/Makefile
+++ b/bloodview/Makefile
@@ -8,6 +8,9 @@ LDFLAGS = -pthread
 CFLAGS += $(shell pkg-config sdl2 SDL2_ttf --cflags)
 LDFLAGS += $(shell pkg-config sdl2 SDL2_ttf --libs)
 
+CFLAGS += $(shell pkg-config libudev --cflags)
+LDFLAGS += $(shell pkg-config libudev --libs)
+
 ifeq ($(VARIANT), release)
 	CFLAGS += -O2 -DNDEBUG
 else
@@ -22,11 +25,18 @@ BV_SRC = \
 	src/bloodview.c \
 	src/main-menu.c \
 	src/data-avg.c \
+	src/device.c \
 	src/graph.c \
 	src/data.c \
 	src/sdl.c
 
 BV_OBJ = $(patsubst %.c,%.o, $(addprefix $(BUILDDIR)/,$(BV_SRC)))
+
+# TODO: improve how we get tool stuff
+TOOL_OBJ = \
+	../tools/device.o \
+	../tools/msg.o \
+	../tools/sig.o
 
 all: bloodview
 clean:
@@ -36,7 +46,7 @@ clean:
 sdl-tk/sdl-tk.a:
 	make -BC sdl-tk VARIANT=$(VARIANT)
 
-bloodview: $(BV_OBJ) sdl-tk/sdl-tk.a
+bloodview: $(BV_OBJ) $(TOOL_OBJ) sdl-tk/sdl-tk.a
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 $(BV_OBJ): $(BUILDDIR)/%.o : %.c

--- a/bloodview/Makefile
+++ b/bloodview/Makefile
@@ -19,7 +19,8 @@ MKDIR =	mkdir -p
 
 BV_SRC = \
 	src/bloodview.c \
-	src/main-menu.c
+	src/main-menu.c \
+	src/sdl.c
 
 BV_OBJ = $(patsubst %.c,%.o, $(addprefix $(BUILDDIR)/,$(BV_SRC)))
 

--- a/bloodview/README.md
+++ b/bloodview/README.md
@@ -1,0 +1,40 @@
+Bloodview: Live-view and control application
+============================================
+
+This is a simple SDL application that controls a Bloodlight device,
+and renders samples on the screen in real time.
+
+It allows the user to configure and run acquisitions from a simple UI.
+Acquisition data is recorded to file in the current working directory,
+with a filename containing the start time of the acquisition.
+
+The main menu
+-------------
+
+The main menu can be opened at any time, and it is though the main
+menu that Bloodview and the device are configured.
+
+| Key                     | Meaning                                 |
+| ----------------------- | --------------------------------------- |
+| <kbd>Esc</kbd>          | Toggle whether the main menu is shown. |
+| <kbd>Return</kbd>       | Activate current menu entry.            |
+| <kbd>Cursor Right</kbd> | Activate current menu entry.            |
+| <kbd>Cursor Left</kbd>  | Traverse up to parent menu.             |
+| <kbd>Cursor Up</kbd>    | Cycle current menu entry up.            |
+| <kbd>Cursor Down</kbd>  | Cycle current menu entry down.          |
+
+If the main menu is open, it will consume keyboard input.
+
+The graph view
+--------------
+
+During an acquisition, graphs are drawn in real time, to show the progress
+of the acquisition.
+
+| Key                     | Meaning                             |
+| ----------------------- | ----------------------------------- |
+| <kbd>Return</kbd>       | Toggle single graph mode.           |
+| <kbd>Cursor Up</kbd>    | Increase scale in the Y direction.  |
+| <kbd>Cursor Down</kbd>  | Decrease scale in the Y direction.  |
+| <kbd>Page Up</kbd>      | Cycle current graph selection up.   |
+| <kbd>Page Down</kbd>    | Cycle current graph selection down. |

--- a/bloodview/resources/lsan-suppr
+++ b/bloodview/resources/lsan-suppr
@@ -1,0 +1,16 @@
+# When running on X, the `SDL_Init()` call eventually calls through
+# to some X code, namely:
+#
+#     char *XSetLocaleModifiers(char *modifier_list);
+#
+# Which returns an allocated string that applications are not allowed
+# to free:
+#
+#     $ sudo apt install libx11-doc
+#     $ man XSetLocaleModifiers
+#
+# > The returned modifiers string is owned by Xlib and should  not
+# > be  modified  or freed by the client.  It may be freed by Xlib
+# > after the current locale  or  modifiers  are  changed.   Until
+# > freed, it will not be modified by Xlib.
+leak:_XlcDefaultMapModifiers

--- a/bloodview/sdl-tk/.gitignore
+++ b/bloodview/sdl-tk/.gitignore
@@ -1,0 +1,2 @@
+build/
+sdl-tk.a

--- a/bloodview/sdl-tk/Makefile
+++ b/bloodview/sdl-tk/Makefile
@@ -1,0 +1,34 @@
+VARIANT = release
+
+BUILDDIR = build/$(VARIANT)
+
+CFLAGS = -Wall -Wextra -pedantic --std=gnu11 -Iinclude -I../..
+LDFLAGS =
+
+CFLAGS += $(shell pkg-config sdl2 SDL2_ttf --cflags)
+LDFLAGS += $(shell pkg-config sdl2 SDL2_ttf --libs)
+
+ifeq ($(VARIANT), release)
+	CFLAGS += -O2 -DNDEBUG
+else
+	CFLAGS += -O0 -g
+	LDFLAGS += -g
+endif
+
+MKDIR =	mkdir -p
+
+LIB_SRC = \
+	src/colour.c
+
+LIB_OBJ = $(patsubst %.c,%.o, $(addprefix $(BUILDDIR)/,$(LIB_SRC)))
+
+all: sdl-tk.a
+clean:
+	rm -rf build sdl-tk.a
+
+sdl-tk.a: $(LIB_OBJ)
+	$(AR) -rcs $@ $^
+
+$(LIB_OBJ): $(BUILDDIR)/%.o : %.c
+	@$(MKDIR) $(BUILDDIR)/src
+	$(CC) $(CFLAGS) -c -o $@ $<

--- a/bloodview/sdl-tk/Makefile
+++ b/bloodview/sdl-tk/Makefile
@@ -20,6 +20,7 @@ MKDIR =	mkdir -p
 LIB_SRC = \
 	src/text.c \
 	src/colour.c \
+	src/widget/action.c \
 	src/widget/widget.c \
 	src/widget/toggle.c
 

--- a/bloodview/sdl-tk/Makefile
+++ b/bloodview/sdl-tk/Makefile
@@ -20,6 +20,7 @@ MKDIR =	mkdir -p
 LIB_SRC = \
 	src/text.c \
 	src/colour.c \
+	src/widget/input.c \
 	src/widget/action.c \
 	src/widget/widget.c \
 	src/widget/toggle.c

--- a/bloodview/sdl-tk/Makefile
+++ b/bloodview/sdl-tk/Makefile
@@ -19,7 +19,8 @@ MKDIR =	mkdir -p
 
 LIB_SRC = \
 	src/text.c \
-	src/colour.c
+	src/colour.c \
+	src/widget/widget.c
 
 LIB_OBJ = $(patsubst %.c,%.o, $(addprefix $(BUILDDIR)/,$(LIB_SRC)))
 

--- a/bloodview/sdl-tk/Makefile
+++ b/bloodview/sdl-tk/Makefile
@@ -20,7 +20,8 @@ MKDIR =	mkdir -p
 LIB_SRC = \
 	src/text.c \
 	src/colour.c \
-	src/widget/widget.c
+	src/widget/widget.c \
+	src/widget/toggle.c
 
 LIB_OBJ = $(patsubst %.c,%.o, $(addprefix $(BUILDDIR)/,$(LIB_SRC)))
 
@@ -32,5 +33,5 @@ sdl-tk.a: $(LIB_OBJ)
 	$(AR) -rcs $@ $^
 
 $(LIB_OBJ): $(BUILDDIR)/%.o : %.c
-	@$(MKDIR) $(BUILDDIR)/src
+	@$(MKDIR) $(BUILDDIR)/src/widget
 	$(CC) $(CFLAGS) -c -o $@ $<

--- a/bloodview/sdl-tk/Makefile
+++ b/bloodview/sdl-tk/Makefile
@@ -20,6 +20,7 @@ MKDIR =	mkdir -p
 LIB_SRC = \
 	src/text.c \
 	src/colour.c \
+	src/widget/menu.c \
 	src/widget/input.c \
 	src/widget/action.c \
 	src/widget/widget.c \

--- a/bloodview/sdl-tk/Makefile
+++ b/bloodview/sdl-tk/Makefile
@@ -18,6 +18,7 @@ endif
 MKDIR =	mkdir -p
 
 LIB_SRC = \
+	src/text.c \
 	src/colour.c
 
 LIB_OBJ = $(patsubst %.c,%.o, $(addprefix $(BUILDDIR)/,$(LIB_SRC)))

--- a/bloodview/sdl-tk/Makefile
+++ b/bloodview/sdl-tk/Makefile
@@ -11,8 +11,8 @@ LDFLAGS += $(shell pkg-config sdl2 SDL2_ttf --libs)
 ifeq ($(VARIANT), release)
 	CFLAGS += -O2 -DNDEBUG
 else
-	CFLAGS += -O0 -g
-	LDFLAGS += -g
+	CFLAGS += -O0 -g -fsanitize=address -fsanitize=undefined -fno-sanitize-recover
+	LDFLAGS += -g -fsanitize=address -fsanitize=undefined -fno-sanitize-recover
 endif
 
 MKDIR =	mkdir -p

--- a/bloodview/sdl-tk/include/sdl-tk/colour.h
+++ b/bloodview/sdl-tk/include/sdl-tk/colour.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SDL_TK_COLOUR_H
+#define SDL_TK_COLOUR_H
+
+#include <stdbool.h>
+
+#include <SDL2/SDL.h>
+
+/**
+ * Colour palette.
+ */
+enum sdl_tk_colour {
+	SDL_TK_COLOUR_BACKGROUND,
+	SDL_TK_COLOUR_INTERFACE,
+	SDL_TK_COLOUR_SELECTION,
+	SDL_TK_COLOUR_DISABLED,
+	SDL_TK_COLOUR_SEL_DIS,
+	SDL_TK_COLOUR__COUNT,
+};
+
+/**
+ * Initialise the colour module.
+ *
+ * \return true on success or false on error.
+ */
+bool sdl_tk_colour_init(void);
+
+/**
+ * Finalise the colour module.
+ */
+void sdl_tk_colour_fini(void);
+
+/**
+ * Get an interface palette colour.
+ *
+ * \param[in]  col  The interface colour to get.
+ * \return the interface colour.
+ */
+SDL_Color sdl_tk_colour_get(enum sdl_tk_colour col);
+
+#endif /* SDL_TK_COLOUR_H */

--- a/bloodview/sdl-tk/include/sdl-tk/text.h
+++ b/bloodview/sdl-tk/include/sdl-tk/text.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SDL_TK_TEXT_H
+#define SDL_TK_TEXT_H
+
+#include <stdbool.h>
+
+#include <SDL2/SDL.h>
+#include <SDL_ttf.h>
+
+#include "colour.h"
+
+/**
+ * An sdl-tk text object.
+ */
+struct sdl_tk_text {
+	unsigned     w;
+	unsigned     h;
+	SDL_Texture *t;
+};
+
+/**
+ * List of sdl-tk text sizes.
+ */
+typedef enum sdl_tk_text_size {
+	SDL_TK_TEXT_SIZE_NORMAL,
+	SDL_TK_TEXT_SIZE_LARGE,
+	SDL_TK_TEXT_SIZE__COUNT,
+} sdl_tk_text_size_t;
+
+/**
+ * Finalise the sdl-tk text module.
+ */
+void sdl_tk_text_fini(
+		void);
+
+/**
+ * Initialise the sdl-tk text module.
+ *
+ * \param[in]  ren        SDL renderer object.
+ * \param[in]  font_path  Path to font to use, or NULL.
+ * \return true on success, or false on failure.
+ */
+bool sdl_tk_text_init(
+		SDL_Renderer *ren,
+		const char   *font_path);
+
+/**
+ * Get an sdl-tk text object from a string.
+ *
+ * \param[in]  string  String to create text object for.
+ * \param[in]  colour  Colour to render the string.
+ * \param[in]  size    Size to render the string.
+ * \return an sdl-tk text object, or NULL on failure.
+ */
+struct sdl_tk_text *sdl_tk_text_create(
+		const char         *string,
+		SDL_Color           colour,
+		sdl_tk_text_size_t  size);
+
+/**
+ * Destroy an sdl-tk text object.
+ *
+ * \param[in]  text  The text object to destroy.
+ */
+void sdl_tk_text_destroy(
+		struct sdl_tk_text *text);
+
+#endif /* SDL_TK_TEXT_H */

--- a/bloodview/sdl-tk/include/sdl-tk/widget.h
+++ b/bloodview/sdl-tk/include/sdl-tk/widget.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SDL_TK_WIDGET_H
+#define SDL_TK_WIDGET_H
+
+#include <stdbool.h>
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
+
+#include "text.h"
+
+struct sdl_tk_widget;
+
+/**
+ * Destroy an sdl-tk widget.
+ *
+ * \param[in]  widget  The widget to destroy.
+ */
+void sdl_tk_widget_destroy(
+		struct sdl_tk_widget *widget);
+
+/**
+ * Render an sdl-tk widget.
+ *
+ * \param[in]  widget  The widget to render.
+ * \param[in]  ren     SDL renderer to use.
+ * \param[in]  x       X coordinate.
+ * \param[in]  y       Y coordinate.
+ */
+void sdl_tk_widget_render(
+		struct sdl_tk_widget *widget,
+		SDL_Renderer         *ren,
+		unsigned              x,
+		unsigned              y);
+
+/**
+ * Fire an sdl-tk widget's action, if any.
+ *
+ * \param[in]  widget  The widget to activate.
+ */
+void sdl_tk_widget_action(
+		struct sdl_tk_widget *widget);
+
+/**
+ * Layout an sdl-tk widget.
+ *
+ * \param[in]  widget  The widget to layout.
+ */
+void sdl_tk_widget_layout(
+		struct sdl_tk_widget *widget);
+
+/**
+ * Fire an input event at an sdl-tk widget.
+ *
+ * \param[in]  widget  The widget to fire input at.
+ * \param[in]  event   The input event to be handled.
+ * \return true if the widget handled the input, false otherwise.
+ */
+bool sdl_tk_widget_input(
+		struct sdl_tk_widget *widget,
+		SDL_Event            *event);
+
+/**
+ * Set whether an sdl-tk widget has input focus.
+ *
+ * \param[in]  widget  The widget to set focus for.
+ * \param[in]  focus   Whether the widget should have focus or not.
+ */
+void sdl_tk_widget_focus(
+		struct sdl_tk_widget *widget,
+		bool                  focus);
+
+/**
+ * Get the title of an sdl-tk widget.
+ *
+ * \param[in]  widget  The widget to get the title of.
+ * \return the title of an sdl-tk widget, or NULL on error.
+ */
+const char *sdl_tk_widget_get_title(
+		struct sdl_tk_widget *widget);
+
+/**
+ * Get the detail value for an sdl-tk widget, if any.
+ *
+ * \param[in]  widget  The widget to get the detail for.
+ * \param[in]  size    The text size to get the detail rendered at.
+ * \param[in]  col     The text colour to get the detail rendered in.
+ * \return an sdl-tk text object for the detail, or NULL on error.
+ */
+const struct sdl_tk_text *sdl_tk_widget_detail(
+		struct sdl_tk_widget *widget,
+		sdl_tk_text_size_t    size,
+		enum sdl_tk_colour    col);
+
+/**
+ * Set a widget to enabled or disabled.
+ *
+ * \param[in]  widget  The widget to get the detail for.
+ * \param[in]  enable  True if the widget should be enabled, false otherwise.
+ */
+void sdl_tk_widget_enable(
+		struct sdl_tk_widget *widget,
+		bool                  enable);
+
+#endif /* SDL_TK_WIDGET_H */

--- a/bloodview/sdl-tk/include/sdl-tk/widget/action.h
+++ b/bloodview/sdl-tk/include/sdl-tk/widget/action.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SDL_TK_WIDGET_ACTION_H
+#define SDL_TK_WIDGET_ACTION_H
+
+#include "sdl-tk/widget.h"
+
+/**
+ * Callback for activation of the action-type widget.
+ *
+ * \param[in]  pw  Client private context data.
+ */
+typedef void (* sdl_tk_widget_action_cb)(
+		void *pw);
+
+/**
+ * Create an action-type widget.
+ *
+ * \param[in]  parent   Parent widget, or NULL.
+ * \param[in]  title    The widget's title.
+ * \param[in]  cb       Callback for activation of the widget.
+ * \param[in]  pw       Client private context data passed back in cb.
+ * \return a action-type widget or NULL on error.
+ */
+struct sdl_tk_widget *sdl_tk_widget_action_create(
+		struct sdl_tk_widget          *parent,
+		const char                    *title,
+		const sdl_tk_widget_action_cb  cb,
+		void                          *pw);
+
+#endif /* SDL_TK_WIDGET_ACTION_H */

--- a/bloodview/sdl-tk/include/sdl-tk/widget/custom.h
+++ b/bloodview/sdl-tk/include/sdl-tk/widget/custom.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SDL_TK_WIDGET_CUSTOM_H
+#define SDL_TK_WIDGET_CUSTOM_H
+
+#include "sdl-tk/widget.h"
+
+/**
+ * \file
+ * \brief Header for implementing new widgets.
+ *
+ * This only needs to be incuded where you're creating a new widget type.
+ */
+
+/**
+ * Types of input focus for an sdl-tk widget.
+ */
+enum sdl_tk_widget_focus {
+	SDL_TK_WIDGET_FOCUS_NONE,
+	SDL_TK_WIDGET_FOCUS_CHILD,
+	SDL_TK_WIDGET_FOCUS_TARGET,
+};
+
+/**
+ * Common base class of an sdl-tk widget.
+ */
+struct sdl_tk_widget {
+	struct sdl_tk_widget     *parent;
+	enum sdl_tk_widget_focus  focus;
+
+	char *title;
+	bool  disabled;
+
+	unsigned w;
+	unsigned h;
+
+	const struct sdl_tk_widget_vt *t;
+};
+
+/** The sdl-tk widget interface v-table. */
+struct sdl_tk_widget_vt {
+	/**
+	 * Destroy an sdl-tk widget.
+	 *
+	 * \param[in]  widget  The widget to destroy.
+	 */
+	void (*destroy)(
+			struct sdl_tk_widget *widget);
+
+	/**
+	 * Render an sdl-tk widget.
+	 *
+	 * \param[in]  widget  The widget to render.
+	 * \param[in]  ren     SDL renderer to use.
+	 * \param[in]  x       X coordinate.
+	 * \param[in]  y       Y coordinate.
+	 */
+	void (*render)(
+			struct sdl_tk_widget *widget,
+			SDL_Renderer         *ren,
+			unsigned              x,
+			unsigned              y);
+
+	/**
+	 * Fire an sdl-tk widget's action, if any.
+	 *
+	 * \param[in]  widget  The widget to activate.
+	 */
+	void (*action)(
+			struct sdl_tk_widget *widget);
+
+	/**
+	 * Layout an sdl-tk widget.
+	 *
+	 * \param[in]  widget  The widget to layout.
+	 */
+	void (*layout)(
+			struct sdl_tk_widget *widget);
+
+	/**
+	 * Fire an input event at an sdl-tk widget.
+	 *
+	 * \param[in]  widget  The widget to fire input at.
+	 * \param[in]  event   The input event to be handled.
+	 * \return true if the widget handled the input, false otherwise.
+	 */
+	bool (*input)(
+			struct sdl_tk_widget *widget,
+			SDL_Event            *event);
+
+	/**
+	 * Set whether an sdl-tk widget has input focus.
+	 *
+	 * \param[in]  widget  The widget to set focus for.
+	 * \param[in]  focus   Whether the widget should have focus or not.
+	 */
+	void (*focus)(
+			struct sdl_tk_widget *widget,
+			bool                  focus);
+
+	/**
+	 * Get the detail value for an sdl-tk widget, if any.
+	 *
+	 * \param[in]  widget  The widget to get the detail for.
+	 * \param[in]  size    The text size to get the detail rendered at.
+	 * \param[in]  col     The text colour to get the detail rendered in.
+	 * \return an sdl-tk text object for the detail, or NULL on error.
+	 */
+	const struct sdl_tk_text *(*detail)(
+			struct sdl_tk_widget *widget,
+			sdl_tk_text_size_t    size,
+			enum sdl_tk_colour    col);
+};
+
+#define BORDER_WIDTH  2
+#define GUTTER_WIDTH  2
+#define PADDING_WIDTH 2
+#define EDGE_WIDTH    (BORDER_WIDTH + GUTTER_WIDTH + PADDING_WIDTH)
+
+#endif /* SDL_TK_WIDGET_CUSTOM_H */

--- a/bloodview/sdl-tk/include/sdl-tk/widget/input.h
+++ b/bloodview/sdl-tk/include/sdl-tk/widget/input.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SDL_TK_WIDGET_INPUT_H
+#define SDL_TK_WIDGET_INPUT_H
+
+#include "sdl-tk/widget.h"
+
+/**
+ * Callback for input widget change notification and validation.
+ *
+ * \param[in]  pw         Client private context data.
+ * \param[in]  new_value  New input widget value.
+ * \return true to accept the new value. false to reject it.
+ */
+typedef bool (* sdl_tk_widget_input_cb)(
+		void       *pw,
+		const char *new_value);
+
+/**
+ * Create an input-type widget.
+ *
+ * \param[in]  parent   Parent widget, or NULL.
+ * \param[in]  title    The widget's title.
+ * \param[in]  initial  The initial value of the input.
+ * \param[in]  cb       Callback for input change notification and validation.
+ * \param[in]  pw       Client private context data passed back in cb.
+ * \return a input-type widget or NULL on error.
+ */
+struct sdl_tk_widget *sdl_tk_widget_input_create(
+		struct sdl_tk_widget         *parent,
+		const char                   *title,
+		const char                   *initial,
+		const sdl_tk_widget_input_cb  cb,
+		void                         *pw);
+
+/**
+ * Update an input widget's value.
+ *
+ * \param[in]  widget  The input widget to update the value of.
+ * \param[in]  value   The new value to set.
+ * \return true if the widget's value was updated, false otherwise.
+ */
+bool sdl_tk_widget_input_set_value(
+			struct sdl_tk_widget *widget,
+			const char *value);
+
+#endif /* SDL_TK_WIDGET_INPUT_H */

--- a/bloodview/sdl-tk/include/sdl-tk/widget/menu.h
+++ b/bloodview/sdl-tk/include/sdl-tk/widget/menu.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SDL_TK_WIDGET_MENU_H
+#define SDL_TK_WIDGET_MENU_H
+
+#include "sdl-tk/widget.h"
+
+/**
+ * Callback for acquiring widgets for the menu entries during menu creation.
+ *
+ * \param[in]  parent  The widget currently being created.
+ * \param[in]  entry   The entry index to create a widget for.
+ * \param[in]  pw      Client private context data.
+ * \return the created sdl-tk widget for the menu entry or NULL on error.
+ */
+typedef struct sdl_tk_widget *(* sdl_tk_widget_menu_entry_cb)(
+		struct sdl_tk_widget *parent,
+		unsigned entry,
+		void *pw);
+
+/**
+ * Create a menu-type widget.
+ *
+ * The given \ref cb is only called during the execution of this function,
+ * while the menu widget is being constructed.
+ *
+ * \param[in]  parent       Parent widget, or NULL.
+ * \param[in]  title        The widget's title.
+ * \param[in]  entry_count  Number of entries in the menu.
+ * \param[in]  cb           Callback for acquiring widgets for the menu entries.
+ * \param[in]  pw           Client private context data passed back in cb.
+ * \return a menu-type widget or NULL on error.
+ */
+struct sdl_tk_widget *sdl_tk_widget_menu_create(
+		struct sdl_tk_widget        *parent,
+		const char                  *title,
+		unsigned                     entry_count,
+		sdl_tk_widget_menu_entry_cb  cb,
+		void                        *pw);
+
+#endif /* SDL_TK_WIDGET_MENU_H */

--- a/bloodview/sdl-tk/include/sdl-tk/widget/toggle.h
+++ b/bloodview/sdl-tk/include/sdl-tk/widget/toggle.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SDL_TK_WIDGET_TOGGLE_H
+#define SDL_TK_WIDGET_TOGGLE_H
+
+#include "sdl-tk/widget.h"
+
+/**
+ * Callback for toggle widget value change notification.
+ *
+ * \param[in]  pw         Client private context data.
+ * \param[in]  new_value  New toggle widget value.
+ */
+typedef void (* sdl_tk_widget_toggle_cb)(
+		void *pw,
+		bool  new_value);
+
+/**
+ * Create a toggle-type widget.
+ *
+ * \param[in]  parent   Parent widget, or NULL.
+ * \param[in]  title    The widget's title.
+ * \param[in]  initial  The intial value of the toggle.
+ * \param[in]  cb       Callback for value change notification.
+ * \param[in]  pw       Client private context data passed back in cb.
+ * \return a toggle-type widget or NULL on error.
+ */
+struct sdl_tk_widget *sdl_tk_widget_toggle_create(
+		struct sdl_tk_widget          *parent,
+		const char                    *title,
+		bool                           initial,
+		const sdl_tk_widget_toggle_cb  cb,
+		void                          *pw);
+
+#endif /* SDL_TK_WIDGET_TOGGLE_H */

--- a/bloodview/sdl-tk/src/colour.c
+++ b/bloodview/sdl-tk/src/colour.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "sdl-tk/colour.h"
+
+/**
+ * Interface palette.
+ */
+static SDL_Color sdl_tk_colours[SDL_TK_COLOUR__COUNT];
+
+/**
+ * Force a value into the range 0-255.
+ *
+ * \param[in]  val  Value to rescale.
+ * \param[in]  max  Maximum value for input value.
+ * \return rescaled value.
+ */
+static inline uint32_t rescale_255(uint32_t val, uint32_t max)
+{
+	if (val > max) {
+		val = max;
+	}
+
+	return (val * 255 + max / 2) / max;
+}
+
+/**
+ * Convert HSV values to an SDL_Colour.
+ *
+ * \param[in]  h  Hue: Range 0-360
+ * \param[in]  s  Saturation: Range 0-100
+ * \param[in]  v  Value: Range 0-100
+ * \return An SDL_Color object.
+ */
+static SDL_Color sdl_tk_colour__get_hsv(uint32_t h, uint32_t s, uint32_t v)
+{
+	uint8_t sector, remainder, p, q, t;
+
+	h = rescale_255(h, 360);
+	s = rescale_255(s, 100);
+	v = rescale_255(v, 100);
+
+	if (s == 0) {
+		return (SDL_Color) { .r = v, .g = v, .b = v };
+	}
+
+	sector = h / 43;
+	remainder = (h - sector * 43) * 6;
+
+	p = (v * (255 - ( s                          ))) >> 8;
+	q = (v * (255 - ((s * (      remainder)) >> 8))) >> 8;
+	t = (v * (255 - ((s * (255 - remainder)) >> 8))) >> 8;
+
+	switch (sector) {
+	case 0:  return (SDL_Color) { .r = v, .g = t, .b = p };
+	case 1:  return (SDL_Color) { .r = q, .g = v, .b = p };
+	case 2:  return (SDL_Color) { .r = p, .g = v, .b = t };
+	case 3:  return (SDL_Color) { .r = p, .g = q, .b = v };
+	case 4:  return (SDL_Color) { .r = t, .g = p, .b = v };
+	default: return (SDL_Color) { .r = v, .g = p, .b = q };
+	}
+}
+
+/* Exported function, documented in colour.h */
+bool sdl_tk_colour_init(void)
+{
+	sdl_tk_colours[SDL_TK_COLOUR_BACKGROUND] = sdl_tk_colour__get_hsv(  0,   0,   0);
+	sdl_tk_colours[SDL_TK_COLOUR_INTERFACE]  = sdl_tk_colour__get_hsv(225,  70, 100);
+	sdl_tk_colours[SDL_TK_COLOUR_SELECTION]  = sdl_tk_colour__get_hsv( 30,  65, 100);
+	sdl_tk_colours[SDL_TK_COLOUR_DISABLED]   = sdl_tk_colour__get_hsv(225,  70,  50);
+	sdl_tk_colours[SDL_TK_COLOUR_SEL_DIS]    = sdl_tk_colour__get_hsv( 30,  65,  50);
+
+	return true;
+}
+
+/* Exported function, documented in colour.h */
+void sdl_tk_colour_fini(void)
+{
+	/* No-op for now. */
+	return;
+}
+
+/* Exported function, documented in colour.h */
+SDL_Color sdl_tk_colour_get(enum sdl_tk_colour col)
+{
+	return sdl_tk_colours[col];
+}

--- a/bloodview/sdl-tk/src/render.h
+++ b/bloodview/sdl-tk/src/render.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RENDER_H
+#define RENDER_H
+
+/**
+ * Render a rectangle, optionally setting the colour to use.
+ *
+ * \param[in]  ren  SDL renderer to use.
+ * \param[in]  col  Colour to set, or NULL.
+ * \param[in]  r    Rectangle to render.
+ */
+static inline void sdl_tk_render_rect(
+		SDL_Renderer      *ren,
+		SDL_Color         *col,
+		SDL_Rect          *r)
+{
+	if (col != NULL) {
+		SDL_SetRenderDrawColor(ren, col->r, col->g, col->b, 255);
+	}
+	SDL_RenderFillRect(ren, r);
+}
+
+#endif /* RENDER_H */

--- a/bloodview/sdl-tk/src/text.c
+++ b/bloodview/sdl-tk/src/text.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+
+#include "text.h"
+#include "util.h"
+
+/** An sdk-tk text font. */
+struct sdl_font {
+	TTF_Font *font;
+	unsigned  size;
+};
+
+/** Array of common text entries at various sizes and in various colours. */
+static struct sdl_tk_text *sdl_tk_text_common
+		[SDL_TK_TEXT_SIZE__COUNT]
+		[SDL_TK_COLOUR__COUNT]
+		[SDL_TK_TEXT__COUNT];
+
+/** Array of sdl-tk text fonts at multiple sizes. */
+static struct sdl_font sdl_font[] = {
+	[SDL_TK_TEXT_SIZE_NORMAL] = { .font = NULL, .size = 18 },
+	[SDL_TK_TEXT_SIZE_LARGE]  = { .font = NULL, .size = 48 },
+};
+
+/** Text module global reference to the SDL renderer. */
+static SDL_Renderer *sdl_ren_g;
+
+/**
+ * Free the common text objects.
+ */
+static void sdl_tk_text__common_fini(void)
+{
+	for (unsigned i = 0; i < SDL_TK_TEXT_SIZE__COUNT; i++) {
+		for (unsigned j = 0; j < SDL_TK_COLOUR__COUNT; j++) {
+			for (unsigned k = 0; k < SDL_TK_TEXT__COUNT; k++) {
+				sdl_tk_text_destroy(sdl_tk_text_common[i][j][k]);
+				sdl_tk_text_common[i][j][k] = NULL;
+			}
+		}
+	}
+}
+
+/**
+ * Initalise the array of common text objects.
+ */
+static bool sdl_tk_text__common_init(void)
+{
+	static const char *str[] = {
+		[SDL_TK_TEXT_ARROW_RIGHT] = ">",
+		[SDL_TK_TEXT_OFF]         = NULL,
+		[SDL_TK_TEXT_ON]          = "On",
+	};
+
+	for (unsigned i = 0; i < SDL_TK_TEXT_SIZE__COUNT; i++) {
+		for (unsigned j = 0; j < SDL_TK_COLOUR__COUNT; j++) {
+			for (unsigned k = 0; k < SDL_TK_TEXT__COUNT; k++) {
+				if (str[k] == NULL) {
+					continue;
+				}
+				sdl_tk_text_common[i][j][k] = sdl_tk_text_create(
+						str[k],
+						sdl_tk_colour_get(j),
+						i);
+				if (sdl_tk_text_common[i][j][k] == NULL) {
+					goto error;
+				}
+			}
+		}
+	}
+
+	return true;
+
+error:
+	sdl_tk_text__common_fini();
+	return false;
+}
+
+/* Exported function, documented in include/sdl-tk/text.h. */
+void sdl_tk_text_fini(void)
+{
+	for (unsigned i = 0; i < SDL_TK_ARRAY_LEN(sdl_font); i++) {
+		if (sdl_font[i].font != NULL) {
+			TTF_CloseFont(sdl_font[i].font);
+			sdl_font[i].font = NULL;
+		}
+	}
+
+	if (TTF_WasInit()) {
+		TTF_Quit();
+	}
+
+	sdl_tk_text__common_fini();
+
+	sdl_ren_g = NULL;
+}
+
+/* Exported function, documented in include/sdl-tk/text.h. */
+bool sdl_tk_text_init(
+		SDL_Renderer *ren,
+		const char *font_path)
+{
+	if (font_path == NULL) {
+		font_path = "/usr/share/fonts/truetype/freefont/FreeSans.ttf";
+	}
+
+	if (TTF_Init() != 0) {
+		printf("TTF_Init Error: %s\n",
+				TTF_GetError());
+		goto error;
+	}
+
+	for (unsigned i = 0; i < SDL_TK_ARRAY_LEN(sdl_font); i++) {
+		sdl_font[i].font = TTF_OpenFont(font_path, sdl_font[i].size);
+		if (sdl_font[i].font == NULL) {
+			printf("TTF_OpenFont Error: %s\n",
+					TTF_GetError());
+			goto error;
+		}
+	}
+
+	sdl_ren_g = ren;
+
+	if (!sdl_tk_text__common_init()) {
+		goto error;
+	}
+
+	return true;
+
+error:
+	sdl_tk_text_fini();
+	return false;
+}
+
+/* Exported function, documented in include/sdl-tk/text.h. */
+void sdl_tk_text_destroy(
+		struct sdl_tk_text *text)
+{
+	if (text != NULL) {
+		if (text->t != NULL) {
+			SDL_DestroyTexture(text->t);
+		}
+		free(text);
+	}
+}
+
+/* Exported function, documented in include/sdl-tk/text.h. */
+struct sdl_tk_text *sdl_tk_text_create(
+		const char      *string,
+		SDL_Color        colour,
+		sdl_tk_text_size_t  size)
+{
+	struct sdl_tk_text *text;
+	SDL_Surface *surface;
+	int w, h;
+
+	text = calloc(1, sizeof(*text));
+	if (text == NULL) {
+		return NULL;
+	}
+
+	surface = TTF_RenderText_Blended(sdl_font[size].font, string, colour);
+	if (surface == NULL) {
+		fprintf(stderr, "TTF_RenderText_Blended Error: %s\n",
+				TTF_GetError());
+		goto error;
+	}
+
+	text->t = SDL_CreateTextureFromSurface(sdl_ren_g, surface);
+	SDL_FreeSurface(surface);
+	if (text->t == NULL) {
+		fprintf(stderr, "SDL_CreateTextureFromSurface Error: %s\n",
+				SDL_GetError());
+		goto error;
+	}
+
+	if (SDL_QueryTexture(text->t, NULL, NULL, &w, &h) != 0) {
+		fprintf(stderr, "SDL_QueryTexture Error: %s\n",
+				SDL_GetError());
+		goto error;
+	}
+
+	text->w = w;
+	text->h = h;
+
+	return text;
+
+error:
+	sdl_tk_text_destroy(text);
+	return NULL;
+}
+
+/* Exported function, documented in src/text.h. */
+const struct sdl_tk_text *sdl_tk_text_get_common(
+		enum sdl_tk_colour   col,
+		sdl_tk_text_size_t   size,
+		sdl_tk_text_common_t common)
+{
+	return sdl_tk_text_common[size][col][common];
+}

--- a/bloodview/sdl-tk/src/text.h
+++ b/bloodview/sdl-tk/src/text.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TEXT_H
+#define TEXT_H
+
+#include "sdl-tk/text.h"
+
+/** List of common text entries. */
+typedef enum sdl_tk_text_common {
+	SDL_TK_TEXT_ARROW_RIGHT,
+	SDL_TK_TEXT_OFF,
+	SDL_TK_TEXT_ON,
+	SDL_TK_TEXT__COUNT
+} sdl_tk_text_common_t;
+
+/**
+ * Get the sdl-tk text object for an common text entry.
+ *
+ * The returned sdl-tk text object remains valid until the sdl-tk text module
+ * is finalised.
+ *
+ * \param[in]  col     Colour to get.
+ * \param[in]  size    Size to get.
+ * \param[in]  common  Common text entry to get.
+ * \return an sdl-tk text object borrow on success, or NULL on failure.
+ */
+const struct sdl_tk_text *sdl_tk_text_get_common(
+		enum sdl_tk_colour   col,
+		sdl_tk_text_size_t   size,
+		sdl_tk_text_common_t common);
+
+#endif /* TEXT_H */

--- a/bloodview/sdl-tk/src/util.h
+++ b/bloodview/sdl-tk/src/util.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef UTIL_H
+#define UTIL_H
+
+/**
+ * Helper to squash warnings about unused variables.
+ *
+ * \param[in]  _u  The variable that is unused.
+ */
+#define SDL_TK_UNUSED(_u) \
+	((void)(_u))
+
+/**
+ * Helper to get the number of entires in an array.
+ *
+ * \param[in]  _a  Array to get the entry count for.
+ * \return entry count of array.
+ */
+#define SDL_TK_ARRAY_LEN(_a) \
+	((sizeof(_a)) / (sizeof(*_a)))
+
+#endif

--- a/bloodview/sdl-tk/src/widget/action.c
+++ b/bloodview/sdl-tk/src/widget/action.c
@@ -1,0 +1,120 @@
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include "sdl-tk/widget/action.h"
+#include "sdl-tk/widget/custom.h"
+
+#include "../text.h"
+#include "../util.h"
+
+/** The sdl-tk action-type widget object. */
+struct sdl_tk_widget_action {
+	struct sdl_tk_widget base;
+
+	sdl_tk_widget_action_cb cb;
+	void *pw;
+};
+
+/**
+ * Destroy an sdl-tk action widget.
+ *
+ * \param[in]  widget  The widget to destroy.
+ */
+static void sdl_tk_widget_action_destroy(
+		struct sdl_tk_widget *widget)
+{
+	struct sdl_tk_widget_action *action = (struct sdl_tk_widget_action *) widget;
+
+	free(action);
+}
+
+/**
+ * Render an sdl-tk action widget.
+ *
+ * \param[in]  widget  The widget to render.
+ * \param[in]  ren     SDL renderer to use.
+ * \param[in]  x       X coordinate.
+ * \param[in]  y       Y coordinate.
+ */
+static void sdl_tk_widget_action_render(
+		struct sdl_tk_widget *widget,
+		SDL_Renderer      *ren,
+		unsigned           x,
+		unsigned           y)
+{
+	SDL_TK_UNUSED(widget);
+	SDL_TK_UNUSED(ren);
+	SDL_TK_UNUSED(x);
+	SDL_TK_UNUSED(y);
+}
+
+/**
+ * Fire an sdl-tk action widget's action, if any.
+ *
+ * \param[in]  widget  The widget to activate.
+ */
+static void sdl_tk_widget_action_action(
+		struct sdl_tk_widget *widget)
+{
+	struct sdl_tk_widget_action *action = (struct sdl_tk_widget_action *) widget;
+
+	if (action->cb != NULL) {
+		action->cb(action->pw);
+	}
+}
+
+/**
+ * Fire an input event at an sdl-tk action widget.
+ *
+ * \param[in]  widget  The widget to fire input at.
+ * \param[in]  event   The input event to be handled.
+ * \return true if the widget handled the input, false otherwise.
+ */
+static bool sdl_tk_widget_action_input(
+		struct sdl_tk_widget *widget,
+		SDL_Event         *event)
+{
+	SDL_TK_UNUSED(widget);
+	SDL_TK_UNUSED(event);
+
+	return true;
+}
+
+/** The sdk-tk action-type widget v-table. */
+static const struct sdl_tk_widget_vt sdl_tk_widget_action_vt = {
+	.destroy = sdl_tk_widget_action_destroy,
+	.action  = sdl_tk_widget_action_action,
+	.render  = sdl_tk_widget_action_render,
+	.input   = sdl_tk_widget_action_input,
+};
+
+/* Exported function, documented in include/sdl-tk/widget/action.h */
+struct sdl_tk_widget *sdl_tk_widget_action_create(
+		struct sdl_tk_widget          *parent,
+		const char                    *title,
+		const sdl_tk_widget_action_cb  cb,
+		void                          *pw)
+{
+	struct sdl_tk_widget_action *action;
+
+	action = calloc(1, sizeof(*action));
+	if (action == NULL) {
+		return NULL;
+	}
+	action->base.t = &sdl_tk_widget_action_vt;
+	action->base.parent = parent;
+	action->base.title = strdup(title);
+	if (action->base.title == NULL) {
+		goto error;
+	}
+
+	action->cb = cb;
+	action->pw = pw;
+
+	return &action->base;
+
+error:
+	sdl_tk_widget_destroy(&action->base);
+	return NULL;
+}

--- a/bloodview/sdl-tk/src/widget/input.c
+++ b/bloodview/sdl-tk/src/widget/input.c
@@ -1,0 +1,479 @@
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include "sdl-tk/widget/input.h"
+#include "sdl-tk/widget/custom.h"
+
+#include "../text.h"
+#include "../util.h"
+#include "../render.h"
+
+/** The sdl-tk input-type widget object. */
+struct sdl_tk_widget_input {
+	struct sdl_tk_widget  base;
+	struct sdl_tk_text   *title;
+
+	sdl_tk_widget_input_cb  cb;
+	void                   *pw;
+
+	struct sdl_tk_text *detail[SDL_TK_COLOUR__COUNT];
+	char               *value;
+};
+
+static void sdl_tk_widget_input__layout(
+		struct sdl_tk_widget_input *input)
+{
+	struct sdl_tk_text *detail = input->detail[SDL_TK_COLOUR_INTERFACE];
+	unsigned max_width;
+	unsigned height;
+
+	assert(input->title != NULL);
+
+	max_width = input->title->w;
+	height = input->title->h;
+
+	if (detail != NULL) {
+		if (max_width < detail->w) {
+			max_width = detail->w;
+		}
+		height += input->title->h > detail->h ?
+		          input->title->h : detail->h;
+	} else {
+		height += input->title->h;
+	}
+
+	input->base.w = EDGE_WIDTH * 2 + max_width;
+	input->base.h = EDGE_WIDTH * 4 + height;
+}
+
+/**
+ * Layout an sdl-tk input widget.
+ *
+ * \param[in]  widget  The widget to layout.
+ */
+static void sdl_tk_widget_input_layout(
+		struct sdl_tk_widget *widget)
+{
+	struct sdl_tk_widget_input *input = (struct sdl_tk_widget_input *) widget;
+
+	sdl_tk_widget_input__layout(input);
+}
+
+static bool sdl_tk_widget_input__update_detail(
+		struct sdl_tk_widget_input *input)
+{
+	for (unsigned i = 0; i < SDL_TK_COLOUR__COUNT; i++) {
+		sdl_tk_text_destroy(input->detail[i]);
+		input->detail[i] = NULL;
+
+		if (input->value == NULL || strlen(input->value) == 0) {
+			continue;
+		}
+
+		input->detail[i] = sdl_tk_text_create(input->value,
+				sdl_tk_colour_get(i),
+				SDL_TK_TEXT_SIZE_NORMAL);
+		if (input->detail[i] == NULL) {
+			return false;
+		}
+	}
+
+	sdl_tk_widget_input__layout(input);
+
+	return true;
+}
+
+/**
+ * Destroy an sdl-tk input widget.
+ *
+ * \param[in]  widget  The widget to destroy.
+ */
+static void sdl_tk_widget_input_destroy(
+		struct sdl_tk_widget *widget)
+{
+	struct sdl_tk_widget_input *input = (struct sdl_tk_widget_input *) widget;
+
+	for (unsigned i = 0; i < SDL_TK_COLOUR__COUNT; i++) {
+		sdl_tk_text_destroy(input->detail[i]);
+	}
+
+	sdl_tk_text_destroy(input->title);
+	free(input->value);
+	free(input);
+}
+
+/**
+ * Get the detail value for an sdl-tk input widget, if any.
+ *
+ * \param[in]  widget  The input widget to get the detail for.
+ * \param[in]  size    The text size to get the detail rendered at.
+ * \param[in]  col     The text colour to get the detail rendered in.
+ * \return an sdl-tk text object for the detail, or NULL on error.
+ */
+const struct sdl_tk_text *sdl_tk_widget_input_detail(
+		struct sdl_tk_widget *widget,
+		sdl_tk_text_size_t    size,
+		enum sdl_tk_colour    col)
+{
+	struct sdl_tk_widget_input *input = (struct sdl_tk_widget_input *) widget;
+
+	SDL_TK_UNUSED(size);
+
+	return input->detail[col];
+}
+
+/**
+ * Render an sdl-tk input widget.
+ *
+ * \param[in]  widget  The input widget to render.
+ * \param[in]  ren     SDL renderer to use.
+ * \param[in]  x       X coordinate.
+ * \param[in]  y       Y coordinate.
+ */
+static void sdl_tk_widget_input_render(
+		struct sdl_tk_widget *widget,
+		SDL_Renderer         *ren,
+		unsigned              x,
+		unsigned              y)
+{
+	const struct sdl_tk_widget_input *input = (struct sdl_tk_widget_input *) widget;
+	SDL_Color background_col = sdl_tk_colour_get(SDL_TK_COLOUR_BACKGROUND);
+	SDL_Color interface_col = sdl_tk_colour_get(SDL_TK_COLOUR_INTERFACE);
+	SDL_Rect r = {
+		.x = x - widget->w / 2,
+		.y = y - widget->h / 2,
+		.w = widget->w,
+		.h = widget->h,
+	};
+
+	/* Input rectangle (title, border) */
+	sdl_tk_render_rect(ren, &interface_col, &r);
+
+	/* Title text */
+	r.x += EDGE_WIDTH;
+	r.y += EDGE_WIDTH;
+	r.w = input->title->w;
+	r.h = input->title->h;
+	SDL_RenderCopy(ren, input->title->t, NULL, &r);
+	r.x -= EDGE_WIDTH;
+	r.y += EDGE_WIDTH + input->title->h;
+
+	/* Background for input body */
+	r.x += BORDER_WIDTH;
+	r.w = widget->w - BORDER_WIDTH * 2;
+	r.h = widget->h - EDGE_WIDTH * 2 - input->title->h - BORDER_WIDTH;
+	sdl_tk_render_rect(ren, &background_col, &r);
+	r.x -= BORDER_WIDTH;
+
+	if (input->detail[SDL_TK_COLOUR_INTERFACE] != NULL) {
+		r.x += EDGE_WIDTH;
+		r.y += EDGE_WIDTH;
+		r.w = input->detail[SDL_TK_COLOUR_INTERFACE]->w;
+		r.h = input->detail[SDL_TK_COLOUR_INTERFACE]->h;
+		SDL_RenderCopy(ren, input->detail[SDL_TK_COLOUR_INTERFACE]->t,
+				NULL, &r);
+	}
+}
+
+/**
+ * Fire an sdl-tk input widget's action, if any.
+ *
+ * \param[in]  widget  The input widget to activate.
+ */
+static void sdl_tk_widget_input_action(
+		struct sdl_tk_widget *widget)
+{
+	assert(widget->parent != NULL);
+	assert(widget->parent->focus == SDL_TK_WIDGET_FOCUS_TARGET);
+
+	widget->parent->focus = SDL_TK_WIDGET_FOCUS_CHILD;
+	widget->focus = SDL_TK_WIDGET_FOCUS_TARGET;
+}
+
+/**
+ * Update an input widget's value.
+ *
+ * \param[in]  input      Input widget to update value of.
+ * \param[in]  new_value  New value to set.  Ownership is passed in.
+ * \return true if the widget value changed, false otherwise.
+ */
+static bool update_value(
+		struct sdl_tk_widget_input *input,
+		char *new_value)
+{
+	bool updated = false;
+
+	if (new_value == NULL) {
+		return false;
+	}
+
+	if ((input->cb != NULL && input->cb(input->pw, new_value)) ||
+	    (input->cb == NULL)) {
+		free(input->value);
+		input->value = new_value;
+
+		sdl_tk_widget_input__update_detail(input);
+		sdl_tk_widget_input__layout(input);
+
+		updated = true;
+	} else {
+		free(new_value);
+	}
+
+	return updated;
+}
+
+/**
+ * Append a character to an input widget's value.
+ *
+ * \param[in]  input    Input widget to update value for.
+ * \param[in]  c        Character to add to input widget's value.
+ * \param[out] updated  Returns whether the input widget's value was changed.
+ * \return true on success, or false on error.
+ */
+static bool append_char(
+		struct sdl_tk_widget_input *input,
+		char c,
+		bool *updated)
+{
+	size_t len = strlen(input->value);
+	char *new = strdup(input->value);
+	char *temp;
+
+	if (new == NULL) {
+		return false;
+	}
+
+	temp = realloc(new, len + 2);
+	if (temp == NULL) {
+		free(new);
+		return false;
+	}
+	new = temp;
+	new[len] = c;
+	new[len + 1] = '\0';
+
+	*updated = update_value(input, new);
+
+	return true;
+}
+
+/**
+ * Handle keypresses in the input widget.
+ *
+ * TODO: This is very primative at the moment.  It could do with:
+ *       - Cursor display
+ *       - Tracking and handling of modifiers, e.g. shift.
+ */
+static bool sdl_tk_widget_input_input_keypress(
+		struct sdl_tk_widget_input *input,
+		SDL_Keycode                 key)
+{
+	bool handled = true;
+	bool change = false;
+
+	switch (key) {
+	case SDLK_BACKSPACE:
+	{
+		size_t len = strlen(input->value);
+		if (len > 0) {
+			input->value[len - 1] = '\0';
+
+			sdl_tk_widget_input__update_detail(input);
+			sdl_tk_widget_input__layout(input);
+
+			change = true;
+		}
+		break;
+	}
+
+	case SDLK_RETURN:
+		if (input->base.parent != NULL) {
+			struct sdl_tk_widget *parent = input->base.parent;
+			assert(parent->focus == SDL_TK_WIDGET_FOCUS_CHILD);
+
+			input->base.focus = SDL_TK_WIDGET_FOCUS_NONE;
+			parent->focus = SDL_TK_WIDGET_FOCUS_TARGET;
+		}
+		break;
+
+	case SDLK_KP_0: handled = append_char(input, '0', &change); break;
+	case SDLK_KP_1: handled = append_char(input, '1', &change); break;
+	case SDLK_KP_2: handled = append_char(input, '2', &change); break;
+	case SDLK_KP_3: handled = append_char(input, '3', &change); break;
+	case SDLK_KP_4: handled = append_char(input, '4', &change); break;
+	case SDLK_KP_5: handled = append_char(input, '5', &change); break;
+	case SDLK_KP_6: handled = append_char(input, '6', &change); break;
+	case SDLK_KP_7: handled = append_char(input, '7', &change); break;
+	case SDLK_KP_8: handled = append_char(input, '8', &change); break;
+	case SDLK_KP_9: handled = append_char(input, '9', &change); break;
+
+	default:
+		if (key >= ' ' && key <= 'z') {
+			handled = append_char(input, (char) key, &change);
+		} else {
+			handled = false;
+		}
+
+		break;
+	}
+
+	if (change) {
+		if (input->base.parent != NULL) {
+			sdl_tk_widget_layout(input->base.parent);
+		}
+	}
+
+	return handled;
+}
+
+/**
+ * Fire an input event at an sdl-tk input widget.
+ *
+ * \param[in]  widget  The input widget to fire input at.
+ * \param[in]  event   The input event to be handled.
+ * \return true if the widget handled the input, false otherwise.
+ */
+static bool sdl_tk_widget_input_input(
+		struct sdl_tk_widget *widget,
+		SDL_Event            *event)
+{
+	struct sdl_tk_widget_input *input = (struct sdl_tk_widget_input *) widget;
+
+	switch (widget->focus) {
+	case SDL_TK_WIDGET_FOCUS_NONE:
+		break;
+
+	case SDL_TK_WIDGET_FOCUS_CHILD:
+		assert(widget->focus != SDL_TK_WIDGET_FOCUS_CHILD);
+		break;
+
+	case SDL_TK_WIDGET_FOCUS_TARGET:
+		switch (event->type) {
+		case SDL_KEYDOWN:
+			return sdl_tk_widget_input_input_keypress(input,
+					event->key.keysym.sym);
+
+		case SDL_MOUSEMOTION:
+		case SDL_MOUSEBUTTONUP:
+		case SDL_MOUSEBUTTONDOWN:
+			break;
+		}
+		break;
+	}
+
+	return false;
+}
+
+/**
+ * Set whether an sdl-tk input widget has input focus.
+ *
+ * \param[in]  widget  The input widget to set focus for.
+ * \param[in]  focus   Whether the widget should have focus or not.
+ */
+static void sdl_tk_widget_input_focus(
+		struct sdl_tk_widget *widget,
+		bool                  focus)
+{
+	if (widget->focus == SDL_TK_WIDGET_FOCUS_NONE ||
+	    widget->focus == SDL_TK_WIDGET_FOCUS_TARGET) {
+		widget->focus = (focus) ?
+				SDL_TK_WIDGET_FOCUS_TARGET :
+				SDL_TK_WIDGET_FOCUS_NONE;
+	}
+
+	if (widget->parent != NULL) {
+		assert(widget->parent->focus == SDL_TK_WIDGET_FOCUS_CHILD);
+		widget->parent->focus = SDL_TK_WIDGET_FOCUS_TARGET;
+	}
+}
+
+/** The sdk-tk input-type widget v-table. */
+static const struct sdl_tk_widget_vt sdl_tk_widget_input_vt = {
+	.destroy = sdl_tk_widget_input_destroy,
+	.action  = sdl_tk_widget_input_action,
+	.detail  = sdl_tk_widget_input_detail,
+	.layout  = sdl_tk_widget_input_layout,
+	.render  = sdl_tk_widget_input_render,
+	.input   = sdl_tk_widget_input_input,
+	.focus   = sdl_tk_widget_input_focus,
+};
+
+/* Exported function, documented in include/sdl-tk/widget/input.h */
+struct sdl_tk_widget *sdl_tk_widget_input_create(
+		struct sdl_tk_widget         *parent,
+		const char                   *title,
+		const char                   *initial,
+		const sdl_tk_widget_input_cb  cb,
+		void                         *pw)
+{
+	struct sdl_tk_widget_input *input;
+	char *value;
+
+	input = calloc(1, sizeof(*input));
+	if (input == NULL) {
+		return NULL;
+	}
+	input->base.t = &sdl_tk_widget_input_vt;
+	input->base.parent = parent;
+	input->base.title = strdup(title);
+	if (input->base.title == NULL) {
+		goto error;
+	}
+
+	input->title = sdl_tk_text_create(title,
+			sdl_tk_colour_get(SDL_TK_COLOUR_BACKGROUND),
+			SDL_TK_TEXT_SIZE_NORMAL);
+	if (input->title == NULL) {
+		goto error;
+	}
+
+	input->cb = cb;
+	input->pw = pw;
+
+	value = strdup((initial != NULL) ? initial : "");
+	if (value == NULL) {
+		goto error;
+	}
+
+	if (!update_value(input, value)) {
+		goto error;
+	}
+
+	if (!sdl_tk_widget_input__update_detail(input)) {
+		goto error;
+	}
+
+	return &input->base;
+
+error:
+	sdl_tk_widget_destroy(&input->base);
+	return NULL;
+}
+
+/* Exported function, documented in include/sdl-tk/widget/input.h */
+bool sdl_tk_widget_input_set_value(
+			struct sdl_tk_widget *widget,
+			const char *value)
+{
+	struct sdl_tk_widget_input *input;
+	bool updated;
+
+	if (widget->t != &sdl_tk_widget_input_vt) {
+		fprintf(stderr, "Error: Called %s with non input widget",
+				__func__);
+		return false;
+	}
+
+	input = (struct sdl_tk_widget_input *) widget;
+	updated = update_value(input, strdup(value));
+
+	if (updated) {
+		if (input->base.parent != NULL) {
+			sdl_tk_widget_layout(input->base.parent);
+		}
+	}
+
+	return updated;
+}

--- a/bloodview/sdl-tk/src/widget/menu.c
+++ b/bloodview/sdl-tk/src/widget/menu.c
@@ -1,0 +1,550 @@
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include "sdl-tk/widget/menu.h"
+#include "sdl-tk/widget/custom.h"
+
+#include "../text.h"
+#include "../util.h"
+#include "../render.h"
+
+/** Menu entry state. */
+enum sdl_tk_widget_state {
+	SDL_TK_WIDGET_NORMAL,
+	SDL_TK_WIDGET_SELECTED,
+	SDL_TK_WIDGET_DISABLED,
+	SDL_TK_WIDGET__COUNT,
+};
+
+/** Menu entry object. */
+struct sdl_tk_widget_menu_entry {
+	struct sdl_tk_text       *title[SDL_TK_WIDGET__COUNT];
+	const struct sdl_tk_text *detail[SDL_TK_WIDGET__COUNT];
+	struct sdl_tk_widget     *widget;
+};
+
+/** The sdl-tk menu-type widget object. */
+struct sdl_tk_widget_menu {
+	struct sdl_tk_widget  base;
+	struct sdl_tk_text   *title;
+
+	struct sdl_tk_widget_menu_entry *entries;
+	unsigned                         count;
+	unsigned                         current;
+};
+
+/**
+ * Destroy an sdl-tk menu widget.
+ *
+ * \param[in]  widget  The widget to destroy.
+ */
+static void sdl_tk_widget_menu_destroy(
+		struct sdl_tk_widget *widget)
+{
+	struct sdl_tk_widget_menu *menu = (struct sdl_tk_widget_menu *) widget;
+
+	for (unsigned i = 0; i < menu->count; i++) {
+		struct sdl_tk_widget_menu_entry *entry = &menu->entries[i];
+
+		sdl_tk_text_destroy(entry->title[SDL_TK_WIDGET_DISABLED]);
+		sdl_tk_text_destroy(entry->title[SDL_TK_WIDGET_SELECTED]);
+		sdl_tk_text_destroy(entry->title[SDL_TK_WIDGET_NORMAL]);
+		sdl_tk_widget_destroy(entry->widget);
+	}
+
+	sdl_tk_text_destroy(menu->title);
+	free(menu->entries);
+	free(menu);
+}
+
+static enum sdl_tk_widget_state sdl_tk_entry_state(
+		const struct sdl_tk_widget_menu *menu,
+		const struct sdl_tk_widget_menu_entry *entry)
+{
+	if ((entry - menu->entries) == menu->current) {
+		return SDL_TK_WIDGET_SELECTED;
+	}
+	if (entry->widget->disabled) {
+		return SDL_TK_WIDGET_DISABLED;
+	}
+	return SDL_TK_WIDGET_NORMAL;
+}
+
+/**
+ * Render an sdl-tk menu widget.
+ *
+ * \param[in]  widget  The widget to render.
+ * \param[in]  ren     SDL renderer to use.
+ * \param[in]  x       X coordinate.
+ * \param[in]  y       Y coordinate.
+ */
+static void sdl_tk_widget_menu_render(
+		struct sdl_tk_widget *widget,
+		SDL_Renderer         *ren,
+		unsigned              x,
+		unsigned              y)
+{
+	const struct sdl_tk_widget_menu *menu = (struct sdl_tk_widget_menu *) widget;
+	SDL_Color background_col = sdl_tk_colour_get(SDL_TK_COLOUR_BACKGROUND);
+	SDL_Color interface_col = sdl_tk_colour_get(SDL_TK_COLOUR_INTERFACE);
+	SDL_Color selection_col = sdl_tk_colour_get(SDL_TK_COLOUR_SELECTION);
+	SDL_Color sel_dis_col = sdl_tk_colour_get(SDL_TK_COLOUR_SEL_DIS);
+	SDL_Rect r = {
+		.x = x - widget->w / 2,
+		.y = y - widget->h / 2,
+		.w = widget->w,
+		.h = widget->h,
+	};
+
+	if (widget->focus == SDL_TK_WIDGET_FOCUS_CHILD) {
+		sdl_tk_widget_render(menu->entries[menu->current].widget,
+				ren, x, y);
+		return;
+	}
+
+	/* Menu rectangle (title, border) */
+	sdl_tk_render_rect(ren, &interface_col, &r);
+
+	/* Title text */
+	r.x += EDGE_WIDTH;
+	r.y += EDGE_WIDTH;
+	r.w = menu->title->w;
+	r.h = menu->title->h;
+	SDL_RenderCopy(ren, menu->title->t, NULL, &r);
+	r.x -= EDGE_WIDTH;
+	r.y += EDGE_WIDTH + menu->title->h;
+
+	/* Background for menu body */
+	r.x += BORDER_WIDTH;
+	r.w = widget->w - BORDER_WIDTH * 2;
+	r.h = widget->h - EDGE_WIDTH * 2 - menu->title->h - BORDER_WIDTH;
+	sdl_tk_render_rect(ren, &background_col, &r);
+	r.y += GUTTER_WIDTH;
+
+	for (unsigned i = 0; i < menu->count; i++) {
+		const struct sdl_tk_widget_menu_entry *entry = &menu->entries[i];
+		const struct sdl_tk_text *title = entry->title[
+				sdl_tk_entry_state(menu, entry)];
+		const struct sdl_tk_text *detail = entry->detail[
+				sdl_tk_entry_state(menu, entry)];
+		unsigned entry_height = title->h;
+
+		r.x += GUTTER_WIDTH;
+		r.w = widget->w - (BORDER_WIDTH + GUTTER_WIDTH) * 2;
+		r.h = title->h;
+
+		if (menu->current == i) {
+			/* Selected entry background. */
+			sdl_tk_render_rect(ren, entry->widget->disabled ?
+					&sel_dis_col : &selection_col, &r);
+		}
+		r.x += PADDING_WIDTH;
+		r.w = title->w;
+
+		/* Entry title */
+		SDL_RenderCopy(ren, title->t, NULL, &r);
+
+		if (detail != NULL) {
+			unsigned detail_offset = widget->w
+					- EDGE_WIDTH * 2
+					- detail->w;
+			r.x += detail_offset;
+			r.w = detail->w;
+			r.h = detail->h;
+			SDL_RenderCopy(ren, detail->t, NULL, &r);
+			r.x -= detail_offset;
+
+			if (entry_height < detail->h) {
+				entry_height = detail->h;
+			}
+		}
+		r.x -= PADDING_WIDTH + GUTTER_WIDTH;
+		r.y += entry_height;
+	}
+}
+
+/**
+ * Fire an sdl-tk menu widget's action, if any.
+ *
+ * \param[in]  widget  The widget to activate.
+ */
+static void sdl_tk_widget_menu_action(
+		struct sdl_tk_widget *widget)
+{
+	assert(widget->parent != NULL);
+	assert(widget->parent->focus == SDL_TK_WIDGET_FOCUS_TARGET);
+
+	widget->parent->focus = SDL_TK_WIDGET_FOCUS_CHILD;
+	widget->focus = SDL_TK_WIDGET_FOCUS_TARGET;
+}
+
+/**
+ * Navigate the focused menu entry up.
+ *
+ * \param[in]  menu  The menu widget to navigate.
+ */
+static void menu__nav_up_internal(struct sdl_tk_widget_menu *menu)
+{
+	if (menu->current == 0) {
+		menu->current = menu->count - 1;
+	} else {
+		menu->current--;
+	}
+}
+
+/**
+ * Navigate the focused menu entry down.
+ *
+ * \param[in]  menu  The menu widget to navigate.
+ */
+static void menu__nav_down_internal(struct sdl_tk_widget_menu *menu)
+{
+	if (menu->current == menu->count - 1) {
+		menu->current = 0;
+	} else {
+		menu->current++;
+	}
+}
+
+/**
+ * Navigate the focused menu entry up.
+ *
+ * \param[in]  menu  The menu widget to navigate.
+ */
+static void menu__nav_up(struct sdl_tk_widget_menu *menu)
+{
+	unsigned current = menu->current;
+
+	do {
+		menu__nav_up_internal(menu);
+	} while (menu->entries[menu->current].widget->disabled &&
+		 menu->current != current);
+}
+
+/**
+ * Navigate the focused menu entry down.
+ *
+ * \param[in]  menu  The menu widget to navigate.
+ */
+static void menu__nav_down(struct sdl_tk_widget_menu *menu)
+{
+	unsigned current = menu->current;
+
+	do {
+		menu__nav_down_internal(menu);
+	} while (menu->entries[menu->current].widget->disabled &&
+		 menu->current != current);
+}
+
+/**
+ * Layout an sdl-tk menu widget.
+ *
+ * \param[in]  menu  The menu widget to layout.
+ */
+static void sdl_tk_widget_menu__layout(
+		struct sdl_tk_widget_menu *menu)
+{
+	unsigned detail_max_width = 0;
+	unsigned title_max_width = 0;
+	unsigned max_width;
+	unsigned height;
+
+	assert(menu->title != NULL);
+
+	max_width = menu->title->w;
+	height = menu->title->h;
+
+	if (menu->entries[menu->current].widget->disabled) {
+		menu__nav_down(menu);
+	}
+
+	for (unsigned i = 0; i < menu->count; i++) {
+		struct sdl_tk_widget_menu_entry *entry = &menu->entries[i];
+		const struct sdl_tk_text *title = entry->title[SDL_TK_WIDGET_NORMAL];
+		const struct sdl_tk_text *detail;
+		unsigned entry_height;
+
+		if (title == NULL) {
+			continue;
+		}
+
+		entry->detail[SDL_TK_WIDGET_NORMAL] = sdl_tk_widget_detail(
+				entry->widget,
+				SDL_TK_TEXT_SIZE_NORMAL,
+				SDL_TK_COLOUR_INTERFACE);
+
+		entry->detail[SDL_TK_WIDGET_SELECTED] = sdl_tk_widget_detail(
+				entry->widget,
+				SDL_TK_TEXT_SIZE_NORMAL,
+				SDL_TK_COLOUR_BACKGROUND);
+
+		entry->detail[SDL_TK_WIDGET_DISABLED] = sdl_tk_widget_detail(
+				entry->widget,
+				SDL_TK_TEXT_SIZE_NORMAL,
+				SDL_TK_COLOUR_DISABLED);
+
+		if (title_max_width < title->w) {
+			title_max_width = title->w;
+		}
+		entry_height = title->h;
+
+		detail = entry->detail[SDL_TK_WIDGET_NORMAL];
+		if (detail != NULL) {
+			if (detail_max_width < detail->w) {
+				detail_max_width = detail->w;
+			}
+			if (entry_height < detail->h) {
+				entry_height = detail->h;
+			}
+		}
+
+		height += entry_height;
+	}
+
+	if (max_width < title_max_width + EDGE_WIDTH * 4 + detail_max_width) {
+		max_width = title_max_width + EDGE_WIDTH * 4 + detail_max_width;
+	}
+
+	menu->base.w = EDGE_WIDTH * 2 + max_width;
+	menu->base.h = EDGE_WIDTH * 2 + height
+			+ BORDER_WIDTH + GUTTER_WIDTH * 2;
+}
+
+/**
+ * Layout an sdl-tk menu widget.
+ *
+ * \param[in]  widget  The widget to layout.
+ */
+static void sdl_tk_widget_menu_layout(
+		struct sdl_tk_widget *widget)
+{
+	struct sdl_tk_widget_menu *menu = (struct sdl_tk_widget_menu *) widget;
+
+	sdl_tk_widget_menu__layout(menu);
+}
+
+/**
+ * Get the detail value for an sdl-tk menu widget.
+ *
+ * \param[in]  widget  The widget to get the detail for.
+ * \param[in]  size    The text size to get the detail rendered at.
+ * \param[in]  col     The text colour to get the detail rendered in.
+ * \return an sdl-tk text object for the detail, or NULL on error.
+ */
+const struct sdl_tk_text *sdl_tk_widget_menu_detail(
+		struct sdl_tk_widget *widget,
+		sdl_tk_text_size_t    size,
+		enum sdl_tk_colour    col)
+{
+	SDL_TK_UNUSED(widget);
+
+	return sdl_tk_text_get_common(col, size, SDL_TK_TEXT_ARROW_RIGHT);
+}
+
+/**
+ * Handle a keypress.
+ *
+ * \param[in]  menu  Menu widget.
+ * \param[in]  key   The keypress to handle.
+ * \return true if the widget handled the input, false otherwise.
+ */
+static bool sdl_tk_widget_menu_input_keypress(
+		struct sdl_tk_widget_menu *menu,
+		SDL_Keycode                key)
+{
+	switch (key) {
+	case SDLK_UP:
+		menu__nav_up(menu);
+		break;
+
+	case SDLK_DOWN:
+		menu__nav_down(menu);
+		break;
+
+	case SDLK_RIGHT: /* Fall though */
+	case SDLK_SPACE: /* Fall though */
+	case SDLK_RETURN:
+		sdl_tk_widget_action(menu->entries[menu->current].widget);
+		break;
+
+	case SDLK_LEFT:
+		if (menu->base.parent != NULL) {
+			struct sdl_tk_widget *parent = menu->base.parent;
+			assert(parent->focus == SDL_TK_WIDGET_FOCUS_CHILD);
+
+			menu->base.focus = SDL_TK_WIDGET_FOCUS_NONE;
+			parent->focus = SDL_TK_WIDGET_FOCUS_TARGET;
+		}
+		break;
+
+	default:
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Fire an input event at an sdl-tk menu widget.
+ *
+ * \param[in]  widget  The widget to fire input at.
+ * \param[in]  event   The input event to be handled.
+ * \return true if the widget handled the input, false otherwise.
+ */
+static bool sdl_tk_widget_menu_input(
+		struct sdl_tk_widget *widget,
+		SDL_Event            *event)
+{
+	struct sdl_tk_widget_menu *menu = (struct sdl_tk_widget_menu *) widget;
+
+	switch (widget->focus) {
+	case SDL_TK_WIDGET_FOCUS_NONE:
+		break;
+
+	case SDL_TK_WIDGET_FOCUS_CHILD:
+		return sdl_tk_widget_input(
+				menu->entries[menu->current].widget,
+				event);
+
+	case SDL_TK_WIDGET_FOCUS_TARGET:
+		switch (event->type) {
+		case SDL_KEYDOWN:
+			return sdl_tk_widget_menu_input_keypress(menu,
+					event->key.keysym.sym);
+
+		case SDL_MOUSEMOTION:
+		case SDL_MOUSEBUTTONUP:
+		case SDL_MOUSEBUTTONDOWN:
+			break;
+		}
+		break;
+	}
+
+	return false;
+}
+
+/**
+ * Set whether an sdl-tk menu widget has input focus.
+ *
+ * \param[in]  widget  The widget to set focus for.
+ * \param[in]  focus   Whether the widget should have focus or not.
+ */
+static void sdl_tk_widget_menu_focus(
+		struct sdl_tk_widget *widget,
+		bool                  focus)
+{
+	struct sdl_tk_widget_menu *menu = (struct sdl_tk_widget_menu *) widget;
+
+	if (widget->focus == SDL_TK_WIDGET_FOCUS_CHILD) {
+		sdl_tk_widget_focus(
+				menu->entries[menu->current].widget,
+				false);
+
+	}
+
+	if (widget->focus == SDL_TK_WIDGET_FOCUS_NONE ||
+	    widget->focus == SDL_TK_WIDGET_FOCUS_TARGET) {
+		widget->focus = (focus) ?
+				SDL_TK_WIDGET_FOCUS_TARGET :
+				SDL_TK_WIDGET_FOCUS_NONE;
+	}
+
+	if (widget->parent != NULL) {
+		assert(widget->parent->focus == SDL_TK_WIDGET_FOCUS_CHILD);
+		widget->parent->focus = SDL_TK_WIDGET_FOCUS_TARGET;
+	}
+}
+
+/** The sdk-tk menu-type widget v-table. */
+static const struct sdl_tk_widget_vt sdl_tk_widget_menu_vt = {
+	.destroy = sdl_tk_widget_menu_destroy,
+	.action  = sdl_tk_widget_menu_action,
+	.detail  = sdl_tk_widget_menu_detail,
+	.layout  = sdl_tk_widget_menu_layout,
+	.render  = sdl_tk_widget_menu_render,
+	.input   = sdl_tk_widget_menu_input,
+	.focus   = sdl_tk_widget_menu_focus,
+};
+
+/* Exported function, documented in include/sdl-tk/widget/menu.h */
+struct sdl_tk_widget *sdl_tk_widget_menu_create(
+		struct sdl_tk_widget        *parent,
+		const char                  *title,
+		unsigned                     entry_count,
+		sdl_tk_widget_menu_entry_cb  cb,
+		void                        *pw)
+{
+	struct sdl_tk_widget_menu *menu;
+
+	menu = calloc(1, sizeof(*menu));
+	if (menu == NULL) {
+		return NULL;
+	}
+	menu->base.t = &sdl_tk_widget_menu_vt;
+	menu->base.parent = parent;
+	menu->base.title = strdup(title);
+	if (menu->base.title == NULL) {
+		goto error;
+	}
+
+	menu->title = sdl_tk_text_create(title,
+			sdl_tk_colour_get(SDL_TK_COLOUR_BACKGROUND),
+			SDL_TK_TEXT_SIZE_NORMAL);
+	if (menu->title == NULL) {
+		goto error;
+	}
+
+	menu->entries = calloc(entry_count, sizeof(*menu->entries));
+	if (menu->entries == NULL) {
+		goto error;
+	}
+
+	menu->count = entry_count;
+	for (unsigned i = 0; i < entry_count; i++) {
+		struct sdl_tk_widget_menu_entry *entry = &menu->entries[i];
+		const char *entry_title;
+
+		entry->widget = cb(&menu->base, i, pw);
+		if (entry->widget == NULL) {
+			goto error;
+		}
+
+		entry_title = sdl_tk_widget_get_title(entry->widget);
+		if (entry_title == NULL) {
+			goto error;
+		}
+
+		entry->title[SDL_TK_WIDGET_NORMAL] = sdl_tk_text_create(
+				entry_title,
+				sdl_tk_colour_get(SDL_TK_COLOUR_INTERFACE),
+				SDL_TK_TEXT_SIZE_NORMAL);
+		if (entry->title[SDL_TK_WIDGET_NORMAL] == NULL) {
+			goto error;
+		}
+
+		entry->title[SDL_TK_WIDGET_SELECTED] = sdl_tk_text_create(
+				entry_title,
+				sdl_tk_colour_get(SDL_TK_COLOUR_BACKGROUND),
+				SDL_TK_TEXT_SIZE_NORMAL);
+		if (entry->title[SDL_TK_WIDGET_SELECTED] == NULL) {
+			goto error;
+		}
+
+		entry->title[SDL_TK_WIDGET_DISABLED] = sdl_tk_text_create(
+				entry_title,
+				sdl_tk_colour_get(SDL_TK_COLOUR_DISABLED),
+				SDL_TK_TEXT_SIZE_NORMAL);
+		if (entry->title[SDL_TK_WIDGET_DISABLED] == NULL) {
+			goto error;
+		}
+	}
+
+	sdl_tk_widget_menu__layout(menu);
+
+	return &menu->base;
+
+error:
+	sdl_tk_widget_destroy(&menu->base);
+	return NULL;
+}

--- a/bloodview/sdl-tk/src/widget/toggle.c
+++ b/bloodview/sdl-tk/src/widget/toggle.c
@@ -1,0 +1,160 @@
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include "sdl-tk/widget/custom.h"
+#include "sdl-tk/widget/toggle.h"
+
+#include "../text.h"
+#include "../util.h"
+
+/** The sdl-tk toggle-type widget object. */
+struct sdl_tk_widget_toggle {
+	struct sdl_tk_widget base;
+
+	sdl_tk_widget_toggle_cb  cb;
+	void                    *pw;
+
+	bool value;
+};
+
+/**
+ * Destroy an sdl-tk toggle widget.
+ *
+ * \param[in]  widget  The toggle widget to destroy.
+ */
+static void sdl_tk_widget_toggle_destroy(
+		struct sdl_tk_widget *widget)
+{
+	struct sdl_tk_widget_toggle *toggle = (struct sdl_tk_widget_toggle *) widget;
+
+	free(toggle);
+}
+
+/**
+ * Render an sdl-tk toggle widget.
+ *
+ * \param[in]  widget  The toggle widget to render.
+ * \param[in]  ren     SDL renderer to use.
+ * \param[in]  x       X coordinate.
+ * \param[in]  y       Y coordinate.
+ */
+static void sdl_tk_widget_toggle_render(
+		struct sdl_tk_widget *widget,
+		SDL_Renderer         *ren,
+		unsigned              x,
+		unsigned              y)
+{
+	SDL_TK_UNUSED(widget);
+	SDL_TK_UNUSED(ren);
+	SDL_TK_UNUSED(x);
+	SDL_TK_UNUSED(y);
+}
+
+static void set_value(
+		struct sdl_tk_widget_toggle *toggle,
+		bool value)
+{
+	toggle->value = value;
+
+	if (toggle->cb != NULL) {
+		toggle->cb(toggle->pw, value);
+	}
+}
+
+/**
+ * Fire an sdl-tk toggle widget's action, if any.
+ *
+ * \param[in]  widget  The toggle widget to activate.
+ */
+static void sdl_tk_widget_toggle_action(
+		struct sdl_tk_widget *widget)
+{
+	struct sdl_tk_widget_toggle *toggle = (struct sdl_tk_widget_toggle *) widget;
+
+	set_value(toggle, !toggle->value);
+
+	if (widget->parent != NULL) {
+		sdl_tk_widget_layout(widget->parent);
+	}
+}
+
+/**
+ * Get the detail value for an sdl-tk toggle widget, if any.
+ *
+ * \param[in]  widget  The toggle widget to get the detail for.
+ * \param[in]  size    The text size to get the detail rendered at.
+ * \param[in]  col     The text colour to get the detail rendered in.
+ * \return an sdl-tk text object for the detail, or NULL on error.
+ */
+const struct sdl_tk_text *sdl_tk_widget_toggle_detail(
+		struct sdl_tk_widget *widget,
+		sdl_tk_text_size_t    size,
+		enum sdl_tk_colour    col)
+{
+	struct sdl_tk_widget_toggle *toggle = (struct sdl_tk_widget_toggle *) widget;
+
+	sdl_tk_text_common_t detail = toggle->value ?
+			SDL_TK_TEXT_ON : SDL_TK_TEXT_OFF;
+
+	return sdl_tk_text_get_common(col, size, detail);
+}
+
+/**
+ * Fire an input event at an sdl-tk toggle widget.
+ *
+ * \param[in]  widget  The toggle widget to fire input at.
+ * \param[in]  event   The input event to be handled.
+ * \return true if the widget handled the input, false otherwise.
+ */
+static bool sdl_tk_widget_toggle_input(
+		struct sdl_tk_widget *widget,
+		SDL_Event            *event)
+{
+	SDL_TK_UNUSED(widget);
+	SDL_TK_UNUSED(event);
+
+	return true;
+}
+
+/** The sdk-tk toggle-type widget v-table. */
+static const struct sdl_tk_widget_vt sdl_tk_widget_toggle_vt = {
+	.destroy = sdl_tk_widget_toggle_destroy,
+	.action  = sdl_tk_widget_toggle_action,
+	.detail  = sdl_tk_widget_toggle_detail,
+	.render  = sdl_tk_widget_toggle_render,
+	.input   = sdl_tk_widget_toggle_input,
+};
+
+/* Exported function, documented in include/sdl-tk/widget/toggle.h */
+struct sdl_tk_widget *sdl_tk_widget_toggle_create(
+		struct sdl_tk_widget          *parent,
+		const char                    *title,
+		bool                           initial,
+		const sdl_tk_widget_toggle_cb  cb,
+		void                          *pw)
+{
+	struct sdl_tk_widget_toggle *toggle;
+
+	toggle = calloc(1, sizeof(*toggle));
+	if (toggle == NULL) {
+		return NULL;
+	}
+	toggle->base.t = &sdl_tk_widget_toggle_vt;
+	toggle->base.parent = parent;
+	toggle->base.title = strdup(title);
+	if (toggle->base.title == NULL) {
+		goto error;
+	}
+
+	toggle->cb = cb;
+	toggle->pw = pw;
+
+	set_value(toggle, initial);
+
+	return &toggle->base;
+
+error:
+	sdl_tk_widget_destroy(&toggle->base);
+	return NULL;
+}

--- a/bloodview/sdl-tk/src/widget/widget.c
+++ b/bloodview/sdl-tk/src/widget/widget.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <stdlib.h>
+
+#include "sdl-tk/colour.h"
+
+#include "sdl-tk/widget.h"
+#include "sdl-tk/widget/custom.h"
+
+#include "../text.h"
+
+/* Exported function, documented in include/sdl-tk/widget.h */
+void sdl_tk_widget_destroy(
+		struct sdl_tk_widget *widget)
+{
+	if (widget != NULL) {
+		free(widget->title);
+		assert(widget->t != NULL);
+		assert(widget->t->destroy != NULL);
+		widget->t->destroy(widget);
+	}
+}
+
+/* Exported function, documented in include/sdl-tk/widget.h */
+void sdl_tk_widget_render(
+		struct sdl_tk_widget *widget,
+		SDL_Renderer         *ren,
+		unsigned              x,
+		unsigned              y)
+{
+	if (widget != NULL) {
+		assert(widget->t != NULL);
+		if (widget->t->render != NULL) {
+			if (widget->focus != SDL_TK_WIDGET_FOCUS_NONE) {
+				widget->t->render(widget, ren, x, y);
+			}
+		}
+	}
+}
+
+/* Exported function, documented in include/sdl-tk/widget.h */
+void sdl_tk_widget_action(
+		struct sdl_tk_widget *widget)
+{
+	if (widget != NULL) {
+		if (widget->disabled) {
+			return;
+		}
+		assert(widget->t != NULL);
+		if (widget->t->action != NULL) {
+			widget->t->action(widget);
+		}
+	}
+}
+
+/* Exported function, documented in include/sdl-tk/widget.h */
+void sdl_tk_widget_layout(
+		struct sdl_tk_widget *widget)
+{
+	if (widget != NULL) {
+		assert(widget->t != NULL);
+		if (widget->t->layout != NULL) {
+			widget->t->layout(widget);
+		}
+	}
+}
+
+/* Exported function, documented in include/sdl-tk/widget.h */
+bool sdl_tk_widget_input(
+		struct sdl_tk_widget *widget,
+		SDL_Event         *event)
+{
+	if (widget != NULL) {
+		assert(widget->t != NULL);
+		if (widget->t->input != NULL) {
+			return widget->t->input(widget, event);
+		}
+	}
+
+	return false;
+}
+
+/* Exported function, documented in include/sdl-tk/widget.h */
+void sdl_tk_widget_focus(
+		struct sdl_tk_widget *widget,
+		bool               focus)
+{
+	if (widget != NULL) {
+		assert(widget->t != NULL);
+		if (widget->t->focus != NULL) {
+			widget->t->focus(widget, focus);
+		}
+	}
+}
+
+/* Exported function, documented in include/sdl-tk/widget.h */
+const char *sdl_tk_widget_get_title(
+		struct sdl_tk_widget *widget)
+{
+	return widget->title;
+}
+
+/* Exported function, documented in include/sdl-tk/widget.h */
+const struct sdl_tk_text *sdl_tk_widget_detail(
+		struct sdl_tk_widget *widget,
+		sdl_tk_text_size_t    size,
+		enum sdl_tk_colour    col)
+{
+	if (widget != NULL) {
+		assert(widget->t != NULL);
+		if (widget->t->detail != NULL) {
+			return widget->t->detail(widget, size, col);
+		}
+	}
+
+	return NULL;
+}
+
+/* Exported function, documented in include/sdl-tk/widget.h */
+void sdl_tk_widget_enable(
+		struct sdl_tk_widget *widget,
+		bool                  enable)
+{
+	widget->disabled = !enable;
+
+	if (widget->parent != NULL) {
+		sdl_tk_widget_layout(widget->parent);
+	}
+}

--- a/bloodview/src/bloodview.c
+++ b/bloodview/src/bloodview.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#include "sdl.h"
 #include "util.h"
 #include "main-menu.h"
 
@@ -66,10 +67,17 @@ int main(int argc, char *argv[])
 	BV_UNUSED(argc);
 	BV_UNUSED(argv);
 
-	while (!bloodview_g.quit) {
+	if (!sdl_init(NULL)) {
+		return EXIT_FAILURE;
+	}
+
+	while (!bloodview_g.quit && sdl_handle_input()) {
+		sdl_present();
 	}
 
 	ret = EXIT_SUCCESS;
+
+	sdl_fini();
 
 	return ret;
 }

--- a/bloodview/src/bloodview.c
+++ b/bloodview/src/bloodview.c
@@ -14,9 +14,43 @@
  * limitations under the License.
  */
 
+#include <stdint.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 #include "util.h"
+#include "main-menu.h"
+
+/** Bloodview global context data. */
+static struct {
+	bool quit;
+} bloodview_g;
+
+/* Exported interface, documented in bloodview.h */
+void bloodview_start_cal_cb(void *pw)
+{
+	BV_UNUSED(pw);
+}
+
+/* Exported interface, documented in bloodview.h */
+void bloodview_start_acq_cb(void *pw)
+{
+	BV_UNUSED(pw);
+}
+
+/* Exported interface, documented in bloodview.h */
+void bloodview_stop_cb(void *pw)
+{
+	BV_UNUSED(pw);
+}
+
+/* Exported interface, documented in bloodview.h */
+void bloodview_quit_cb(void *pw)
+{
+	BV_UNUSED(pw);
+
+	bloodview_g.quit = true;
+}
 
 /**
  * Main entry point from OS.
@@ -31,6 +65,9 @@ int main(int argc, char *argv[])
 
 	BV_UNUSED(argc);
 	BV_UNUSED(argv);
+
+	while (!bloodview_g.quit) {
+	}
 
 	ret = EXIT_SUCCESS;
 

--- a/bloodview/src/bloodview.c
+++ b/bloodview/src/bloodview.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+
+#include "util.h"
+
+/**
+ * Main entry point from OS.
+ *
+ * \param[in]  argc  Number of command line parameters.
+ * \param[in]  argv  String vector of command line arguments.
+ * \return Exit code.
+ */
+int main(int argc, char *argv[])
+{
+	int ret = EXIT_FAILURE;
+
+	BV_UNUSED(argc);
+	BV_UNUSED(argv);
+
+	ret = EXIT_SUCCESS;
+
+	return ret;
+}

--- a/bloodview/src/bloodview.h
+++ b/bloodview/src/bloodview.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BLOODVIEW_H
+#define BLOODVIEW_H
+
+/**
+ * Main menu callback for starting a calibration acquisition.
+ *
+ * \param[in]  pw  Client private context data.
+ */
+void bloodview_start_cal_cb(void *pw);
+
+/**
+ * Main menu callback for starting an acquisition.
+ *
+ * \param[in]  pw  Client private context data.
+ */
+void bloodview_start_acq_cb(void *pw);
+
+/**
+ * Main menu callback for stopping acquisition.
+ *
+ * \param[in]  pw  Client private context data.
+ */
+void bloodview_stop_cb(void *pw);
+
+/**
+ * Main menu callback for quitting Bloodview
+ *
+ * \param[in]  pw  Client private context data.
+ */
+void bloodview_quit_cb(void *pw);
+
+#endif /* BLOODVIEW_H */

--- a/bloodview/src/data-avg.c
+++ b/bloodview/src/data-avg.c
@@ -1,0 +1,214 @@
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include "data-avg.h"
+#include "util.h"
+
+/** Channel tracking. */
+struct channel_data {
+	uint32_t *data;
+
+	uint64_t  sum;
+	unsigned  read;
+	unsigned  write;
+	unsigned  capacity;
+	unsigned  utilisation;
+};
+
+/** Averaging filter context. */
+struct data_avg_ctx {
+	struct channel_data *channel;
+	unsigned count;
+
+	bool normalise;
+};
+
+/* Exported interface, documented in data-avg.h */
+void data_avg_fini(void *pw)
+{
+	struct data_avg_ctx *ctx = pw;
+
+	for (unsigned i = 0; i < ctx->count; i++) {
+		free(ctx->channel[i].data);
+	}
+
+	free(ctx->channel);
+	free(ctx);
+}
+
+/**
+ * Allocate the channel array.
+ *
+ * \param[in]  count     The number of channels.
+ * \param[in]  capacity  The sample capacity for each channel.
+ */
+static struct channel_data *data_avg__init_channel_array(
+		unsigned count,
+		unsigned capacity)
+{
+	struct channel_data *channel;
+
+	channel = calloc(sizeof(*channel), count);
+	if (channel == NULL) {
+		return NULL;
+	}
+
+	for (unsigned i = 0; i < count; i++) {
+		size_t size = sizeof(*channel[i].data);
+
+		channel[i].capacity = capacity;
+		channel[i].data = malloc(capacity * size);
+		if (channel[i].data == NULL) {
+			goto error;
+		}
+	}
+
+	return channel;
+
+error:
+	for (unsigned i = 0; i < count; i++) {
+		free(channel[i].data);
+	}
+
+	return NULL;
+}
+
+/* Exported interface, documented in data-avg.h */
+void *data_avg_init(
+		const struct data_avg_config *config,
+		unsigned frequency,
+		unsigned channels,
+		uint32_t src_mask)
+{
+	struct data_avg_ctx *ctx;
+	unsigned capacity;
+
+	BV_UNUSED(src_mask);
+
+	assert(config->filter_freq > 0);
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (ctx == NULL) {
+		return NULL;
+	}
+
+	capacity = frequency / (config->filter_freq / 1024.0);
+
+	ctx->channel = data_avg__init_channel_array(channels, capacity);
+	if (ctx->channel == NULL) {
+		free(ctx);
+		return NULL;
+	}
+
+	ctx->normalise = config->normalise;
+	ctx->count = channels;
+	return ctx;
+}
+
+/**
+ * Advance a position pointer for a channel.
+ *
+ * \param[in]  c    A channel object.
+ * \param[in]  pos  Current position pointer for channel.
+ * \return new pointer position value.
+ */
+static inline unsigned data_avg__advance_pos(
+		const struct channel_data *c,
+		unsigned pos)
+{
+	pos++;
+	return (pos >= c->capacity) ? 0 : pos;
+}
+
+/**
+ * Get a average sample from a channel.
+ *
+ * \param[in]  c  A channel object.
+ * \return Normalised sample.
+ */
+static inline uint32_t data_avg__get_average(
+		const struct channel_data *c)
+{
+	return c->sum / c->utilisation;
+}
+
+/**
+ * Get a normalised sample from a channel.
+ *
+ * \param[in]  c  A channel object.
+ * \return Normalised sample.
+ */
+static inline uint32_t data_avg__get_normalised(
+		const struct channel_data *c,
+		uint32_t sample)
+{
+	return INT32_MAX + sample - data_avg__get_average(c);
+}
+
+/**
+ * Write a sample to a channel buffer.
+ *
+ * \param[in]  c      Channel object.
+ * \param[in]  value  Value to write to channel buffer.
+ */
+static inline void data_avg__add_sample(
+		struct channel_data *c,
+		uint32_t value)
+{
+	assert(c->utilisation < c->capacity);
+
+	c->data[c->write] = value;
+	c->write = data_avg__advance_pos(c, c->write);
+
+	c->utilisation++;
+	c->sum += value;
+}
+
+/**
+ * Drop a sample from a channel buffer.
+ *
+ * \param[in]  c  Channel object.
+ */
+static inline void data_avg__drop_sample(
+		struct channel_data *c)
+{
+	assert(c->utilisation > 0);
+
+	uint32_t old = c->data[c->read];
+	c->read = data_avg__advance_pos(c, c->read);
+
+	c->utilisation--;
+	c->sum -= old;
+}
+
+/* Exported interface, documented in data-avg.h */
+uint32_t data_avg_proc(
+		void *pw,
+		unsigned channel,
+		uint32_t sample)
+{
+	struct data_avg_ctx *ctx = pw;
+	struct channel_data *c;
+	uint32_t value;
+
+	assert(channel < ctx->count);
+
+	c = &ctx->channel[channel];
+
+	data_avg__add_sample(c, sample);
+
+	if (ctx->normalise) {
+		value = data_avg__get_normalised(c, sample);
+	} else {
+		value = data_avg__get_average(c);
+	}
+
+	if (c->utilisation == c->capacity) {
+		data_avg__drop_sample(c);
+	}
+
+	return value;
+}

--- a/bloodview/src/data-avg.h
+++ b/bloodview/src/data-avg.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BV_DATA_AVG_H
+#define BV_DATA_AVG_H
+
+/**
+ * The data averaging filter's configuration.
+ *
+ * The filter frequency indicates with width of the window to average samples
+ * over, and is set in 1/1024ths of a Hz.
+ */
+struct data_avg_config {
+	unsigned filter_freq;
+	bool     normalise;
+};
+
+/**
+ * Finalise a given data averaging filter session.
+ *
+ * \param[in]  pw  Data averaging filter session context.
+ */
+void data_avg_fini(void *pw);
+
+/**
+ * Create a data averaging filter session.
+ *
+ * \param[in]  config     Filter-specific configuration.
+ * \param[in]  frequency  The sampling frequency.
+ * \param[in]  channels   The number of channels.
+ * \param[in]  src_mask   Mask of enabled sources.
+ * \return a context pointer on success, or NULL on error.
+ */
+void *data_avg_init(
+		const struct data_avg_config *config,
+		unsigned frequency,
+		unsigned channels,
+		uint32_t src_mask);
+
+/**
+ * Handle a sample for a given channel.
+ *
+ * \param[in]  pw       The data averaging filter context.
+ * \param[in]  channel  The channel index.
+ * \param[in]  sample   The sample value to filter.
+ * \return true on success, false on error.
+ */
+uint32_t data_avg_proc(
+		void *pw,
+		unsigned channel,
+		uint32_t sample);
+
+#endif /* BV_DATA_AVG_H */

--- a/bloodview/src/data.c
+++ b/bloodview/src/data.c
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include "../../src/msg.h"
+
+#include "data.h"
+#include "util.h"
+#include "graph.h"
+#include "data-avg.h"
+#include "main-menu.h"
+
+struct data_filter {
+	void *ctx;
+
+	void (*fini)(
+			void *pw);
+
+	uint32_t (*proc)(
+			void *pw,
+			unsigned channel,
+			uint32_t sample);
+};
+
+/** Data module global data. */
+static struct {
+	/** Whether the data module has been initialised. */
+	bool enabled;
+
+	/** Acquisition channel to data channel. */
+	unsigned mapping[sizeof(unsigned) * CHAR_BIT];
+
+	/** Array of registered filters. */
+	struct data_filter *filter;
+
+	/** Number of entries in \ref filter. */
+	unsigned count;
+} data_g;
+
+/**
+ * Filter and graph a sample.
+ *
+ * \param[in]  channel  The channel that the sample is for.
+ * \param[in]  sample   The sample to filter.
+ * \return true on success, or false on error.
+ */
+static bool data__process_sample(
+		unsigned channel,
+		uint32_t sample)
+{
+	for (unsigned i = 0; i < data_g.count; i++) {
+		struct data_filter *filter = &data_g.filter[i];
+		sample = filter->proc(filter->ctx, channel, sample);
+	}
+
+	if (!graph_data_add(channel, sample - INT32_MAX)) {
+		return false;
+	}
+
+	return true;
+}
+
+/* Exported interface, documented in data.h */
+bool data_handle_msg_u16(const bl_msg_sample_data_t *msg)
+{
+	unsigned index = msg->channel;
+
+	if (data_g.enabled == false) {
+		return true;
+	}
+
+	assert(msg->type == BL_MSG_SAMPLE_DATA16);
+
+	for (unsigned i = 0; i < msg->count; i++) {
+		if (!data__process_sample(
+				data_g.mapping[index],
+				msg->data16[i])) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/* Exported interface, documented in data.h */
+bool data_handle_msg_u32(const bl_msg_sample_data_t *msg)
+{
+	unsigned index = msg->channel;
+
+	if (data_g.enabled == false) {
+		return true;
+	}
+
+	assert(msg->type == BL_MSG_SAMPLE_DATA32);
+
+	for (unsigned i = 0; i < msg->count; i++) {
+		if (!data__process_sample(
+				data_g.mapping[index],
+				msg->data32[i])) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/* Exported interface, documented in data.h */
+void data_finish(void)
+{
+	data_g.enabled = false;
+
+	for (unsigned i = 0; i < data_g.count; i++) {
+		data_g.filter[i].fini(data_g.filter[i].ctx);
+	}
+
+	free(data_g.filter);
+	data_g.filter = NULL;
+	data_g.count = 0;
+
+	graph_fini();
+}
+
+/**
+ * Increase filter array allocation, and return new filter slot.
+ *
+ * Does not increase the filter count, so the caller must do that.
+ *
+ * \return the new filter allocation, or NULL on error.
+ */
+static struct data_filter *data__allocate_filter(void)
+{
+	struct data_filter *filter;
+	unsigned count = data_g.count;
+
+	filter = realloc(data_g.filter, sizeof(*filter) * (count + 1));
+	if (filter == NULL) {
+		return NULL;
+	}
+
+	data_g.filter = filter;
+
+	filter += count;
+	memset(filter, 0, sizeof(*filter));
+
+	return filter;
+}
+
+/**
+ * Resister the normalising filter, if enabled.
+ *
+ * \param[in]  frequency  The sampling frequency.
+ * \param[in]  channels   The number of channels.
+ * \param[in]  src_mask   Mask of enabled sources.
+ * \return true on success, or false on error.
+ */
+static bool data__register_normalise(
+		unsigned frequency,
+		unsigned channels,
+		uint32_t src_mask)
+{
+	struct data_filter *filter;
+	struct data_avg_config config = {
+		.filter_freq = 1024 * main_menu_conifg_get_filter_normalise_frequency(),
+		.normalise   = true,
+	};
+
+	BV_UNUSED(src_mask);
+
+	filter = data__allocate_filter();
+	if (filter == NULL) {
+		return false;
+	}
+
+	filter->ctx = data_avg_init(&config, frequency, channels, src_mask);
+	if (filter->ctx == NULL) {
+		/* No need to free the filter, it's already owned by the
+		 * global state. */
+		return false;
+	}
+
+	filter->fini = data_avg_fini;
+	filter->proc = data_avg_proc;
+
+	data_g.count++;
+	return true;
+}
+
+/**
+ * Resister the normalising filter, if enabled.
+ *
+ * \param[in]  frequency  The sampling frequency.
+ * \param[in]  channels   The number of channels.
+ * \param[in]  src_mask   Mask of enabled sources.
+ * \return true on success, or false on error.
+ */
+static bool data__register_ac_denoise(
+		unsigned frequency,
+		unsigned channels,
+		uint32_t src_mask)
+{
+	struct data_filter *filter;
+	struct data_avg_config config = {
+		.filter_freq = (frequency / main_menu_conifg_get_filter_ac_denoise_frequency()) * 1024,
+		.normalise   = false,
+	};
+
+	BV_UNUSED(src_mask);
+
+	filter = data__allocate_filter();
+	if (filter == NULL) {
+		return false;
+	}
+
+	filter->ctx = data_avg_init(&config, frequency, channels, src_mask);
+	if (filter->ctx == NULL) {
+		/* No need to free the filter, it's already owned by the
+		 * global state. */
+		return false;
+	}
+
+	filter->fini = data_avg_fini;
+	filter->proc = data_avg_proc;
+
+	data_g.count++;
+	return true;
+}
+
+/**
+ * Initialise the data context.
+ *
+ * \param[in]  calibrate  Whether this is a calibration acquisition.
+ * \param[in]  frequency  The sampling frequency.
+ * \param[in]  channels   The number of channels.
+ * \param[in]  src_mask   Mask of enabled sources.
+ * \return true on success, or false on error.
+ */
+static bool data__register_filters(
+		bool calibrate,
+		unsigned frequency,
+		unsigned channels,
+		uint32_t src_mask)
+{
+	BV_UNUSED(calibrate);
+
+	if (main_menu_conifg_get_filter_normalise_enabled() &&
+			!data__register_normalise(
+					frequency, channels, src_mask)) {
+		return false;
+	}
+
+	if (main_menu_conifg_get_filter_ac_denoise_enabled() &&
+			!data__register_ac_denoise(
+					frequency, channels, src_mask)) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Count the bits sent in a mask
+ *
+ * \param[in]  mask  The mask to count the bits set in.
+ * \return the number of bits set in mask.
+ */
+static unsigned bit_count(unsigned mask)
+{
+	unsigned count = 0;
+
+	for (unsigned i = 0; i < sizeof(mask) * CHAR_BIT; i++) {
+		if (mask & (1u << i)) {
+			count++;
+		}
+	}
+
+	return count;
+}
+
+/* Exported interface, documented in data.h */
+bool data_start(bool calibrate, unsigned frequency, unsigned src_mask)
+{
+	unsigned channels = bit_count(src_mask);
+	unsigned n = 0;
+
+	assert(data_g.enabled == false);
+
+	for (unsigned i = 0; i < BV_ARRAY_LEN(data_g.mapping); i++) {
+		if (src_mask & (1u << i)) {
+			data_g.mapping[i] = n++;
+		} else {
+			data_g.mapping[i] = UINT_MAX;
+		}
+	}
+
+	if (!graph_init()) {
+		return false;
+	}
+
+	if (!data__register_filters(calibrate, frequency, channels, src_mask)) {
+		data_finish();
+		return false;
+	}
+
+	for (unsigned i = 0; i < channels; i++) {
+		if (!graph_create(i, frequency)) {
+			data_finish();
+			return false;
+		}
+	}
+
+	data_g.enabled = true;
+
+	return true;
+}

--- a/bloodview/src/data.h
+++ b/bloodview/src/data.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BV_DATA_H
+#define BV_DATA_H
+
+/**
+ * Finish a data processing session.
+ */
+void data_finish(void);
+
+/**
+ * Start a data processing session.
+ *
+ * \param[in]  calibrate  Whether this is a calibration acquisition.
+ * \param[in]  frequency  The sampling frequency.
+ * \param[in]  src_mask   The source mask.
+ * \return true on success, false on error.
+ */
+bool data_start(bool calibrate, unsigned frequency, unsigned src_mask);
+
+/**
+ * Handle a \ref BL_MSG_SAMPLE_DATA16 message.
+ *
+ * \param[in]  msg  The sample message to process.
+ * \return true on success, false on error.
+ */
+bool data_handle_msg_u16(const bl_msg_sample_data_t *msg);
+
+/**
+ * Handle a \ref BL_MSG_SAMPLE_DATA32 message.
+ *
+ * \param[in]  msg  The sample message to process.
+ * \return true on success, false on error.
+ */
+bool data_handle_msg_u32(const bl_msg_sample_data_t *msg);
+
+#endif /* BV_DATA_H */

--- a/bloodview/src/device.c
+++ b/bloodview/src/device.c
@@ -1,0 +1,791 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <time.h>
+#include <stdio.h>
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include <pthread.h>
+
+#include "../../src/msg.h"
+#include "../../tools/msg.h"
+#include "../../tools/device.h"
+
+#include "data.h"
+#include "util.h"
+#include "device.h"
+#include "main-menu.h"
+
+/** Special code for indicating the start of an acquisition. */
+#define MSG_START_SPECIAL_CAL ((enum bl_msg_type) 255)
+
+/** Special code for indicating the start of a calibration. */
+#define MSG_START_SPECIAL_ACQ ((enum bl_msg_type) 254)
+
+/** A locked unsigned integer. */
+typedef struct locked_uint {
+	pthread_mutex_t lock;
+	unsigned        value;
+} locked_uint_t;
+
+/**
+ * Check whether a locked value is equal to a given value.
+ *
+ * \param[in]  lu     Locked unsigned value to check.
+ * \param[in]  value  The value to compare against.
+ * \return true if the locked unsigned value is equal to the given value.
+ */
+static inline bool locked_uint_is_equal(
+		locked_uint_t *lu,
+		unsigned value)
+{
+	bool ret;
+
+	pthread_mutex_lock(&lu->lock);
+	ret = (lu->value == value);
+	pthread_mutex_unlock(&lu->lock);
+
+	return ret;
+}
+
+/**
+ * Increment a locked unsigned value.
+ *
+ * \param[in]  lu  Locked unsigned value to change.
+ */
+static inline void locked_uint_inc(
+		locked_uint_t *lu)
+{
+	pthread_mutex_lock(&lu->lock);
+	lu->value++;
+	pthread_mutex_unlock(&lu->lock);
+}
+
+/**
+ * Decrement a locked unsigned value.
+ *
+ * \param[in]  lu  Locked unsigned value to change.
+ */
+static inline void locked_uint_dec(
+		locked_uint_t *lu)
+{
+	pthread_mutex_lock(&lu->lock);
+	lu->value--;
+	pthread_mutex_unlock(&lu->lock);
+}
+
+/**
+ * Set a locked unsigned value.
+ *
+ * \param[in]  lu     Locked unsigned value to change.
+ * \param[in]  value  New value.
+ * \return true if the locked value changed, false otherwise.
+ */
+static inline bool locked_uint_set(
+		locked_uint_t *lu,
+		unsigned value)
+{
+	bool ret = false;
+
+	pthread_mutex_lock(&lu->lock);
+	if (lu->value != value) {
+		lu->value = value;
+		ret = true;
+	}
+	pthread_mutex_unlock(&lu->lock);
+	return ret;
+}
+
+/** Maximum number of messages that can be queued for sending. */
+#define MSG_FIFO_MAX 16
+
+/** Device module global context. */
+static struct {
+	locked_uint_t state;
+	int           dev_fd;
+
+	device_state_change_cb  cb;
+	void                   *pw;
+
+	volatile bool quit;
+	pthread_t     thread_id;
+
+	union bl_msg_data msg[MSG_FIFO_MAX];
+	unsigned          msg_next_free;
+	unsigned          msg_next_queued;
+	locked_uint_t     msg_used;
+
+	FILE *rec;
+} bv_device_g;
+
+/**
+ * Advance the a send message queue position pointer.
+ *
+ * \param[in,out]  pos  The position to be advanced.
+ */
+static void device__msg_advance_ptr(unsigned *pos)
+{
+	unsigned new_pos = *pos + 1;
+
+	*pos = (new_pos >= MSG_FIFO_MAX) ? 0 : new_pos;
+}
+
+/**
+ * Get the next free message slot for sending.
+ *
+ * \return pointer to free message, or NULL on error.
+ */
+static inline union bl_msg_data *device__msg_get_next_free(void)
+{
+	if (locked_uint_is_equal(&bv_device_g.msg_used, MSG_FIFO_MAX)) {
+		return NULL;
+	}
+
+	return &bv_device_g.msg[bv_device_g.msg_next_free];
+}
+
+/**
+ * Queue a message for sending.
+ *
+ * \param[in]  msg  The message to be sent.
+ */
+static inline void device__msg_send(const union bl_msg_data *msg)
+{
+	BV_UNUSED(msg);
+
+	device__msg_advance_ptr(&bv_device_g.msg_next_free);
+	locked_uint_inc(&bv_device_g.msg_used);
+}
+
+/**
+ * Get the next message queued for sending.
+ *
+ * \return pointer to the next queued message, or NULL on if there are none.
+ */
+static inline union bl_msg_data *device__msg_get_next_queued(void)
+{
+	if (locked_uint_is_equal(&bv_device_g.msg_used, 0)) {
+		return NULL;
+	}
+
+	return &bv_device_g.msg[bv_device_g.msg_next_queued];
+}
+
+/**
+ * Mark a message on the queued list as sent.
+ *
+ * \param[in]  msg  The message that has been sent.
+ */
+static inline void device__msg_sent(const union bl_msg_data *msg)
+{
+	BV_UNUSED(msg);
+
+	device__msg_advance_ptr(&bv_device_g.msg_next_queued);
+	locked_uint_dec(&bv_device_g.msg_used);
+}
+
+/**
+ * Check whether the device module has been initialised.
+ *
+ * \return true if the device module has been initialised.
+ */
+static inline bool device__is_initialised(void)
+{
+	return !locked_uint_is_equal(&bv_device_g.state, DEVICE_STATE_NONE);
+}
+
+/**
+ * Ensure the device has been initialised.
+ *
+ * \return true if the device module has been initialised.
+ */
+static bool device__ensure_initialised(
+		const char *func)
+{
+	if (!device__is_initialised()) {
+		fprintf(stderr, "%s: Device module not initialised.\n", func);
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Set the device state, and call client callback on changes.
+ *
+ * \param[in]  state  The state to change to.
+ * \return true if the state changed, or false otherwise.
+ */
+static inline bool device__set_state(
+		device_state_t state)
+{
+	bool changed = locked_uint_set(&bv_device_g.state, state);
+
+	if (changed) {
+		bv_device_g.cb(bv_device_g.pw, state);
+	}
+
+	return changed;
+}
+
+/**
+ * Get the current device state.
+ *
+ * Note, this is just a snapshot of the state.  It can be changed in
+ * another thread, and there is nothing to ensure that the state
+ * will still be the same when the caller uses the returned value.
+ *
+ * \return the device state snapshot.
+ */
+static inline device_state_t device__get_current_state(void)
+{
+	return bv_device_g.state.value;
+}
+
+/**
+ * Open a recording file.
+ *
+ * Filenames take the forms:
+ *
+ * * "YYYY-MM-DD HH:MM:SS-cal.yaml"
+ * * "YYYY-MM-DD HH:MM:SS-acq.yaml"
+ *
+ * Files are created in the current working directory.
+ *
+ * \param[in]  calibrate  Whether the recording is for a calibration.
+ * \return The opened file stream or NULL on error.
+ */
+static FILE *device__open_recording(bool calibrate)
+{
+	size_t len;
+	time_t rawtime;
+	struct tm *timeinfo;
+	static char buf[80];
+
+	rawtime = time(NULL);
+	if (rawtime == (time_t)-1) {
+		return NULL;
+	}
+
+	timeinfo = localtime(&rawtime);
+	if (timeinfo == NULL) {
+		fprintf(stderr, "Error calling localtime: %s\n",
+				strerror(errno));
+		return NULL;
+	}
+
+	len = strftime(buf, sizeof(buf), "%Y-%m-%d.%H:%M:%S", timeinfo);
+	assert(len > 0);
+
+	assert(sizeof(buf) > len + 4);
+	memcpy(&buf[len], calibrate ? "-cal" : "-acq", 5);
+	len += 4;
+
+	assert(sizeof(buf) > len + 5);
+	memcpy(&buf[len], ".yaml", 6);
+
+	return fopen(buf, "w+");
+}
+
+/**
+ * Send a queued message, if any.
+ *
+ * \param[out]  sent_type  Returns the type of any sent message.
+ * \return false on error, or true otherwise.
+ */
+static bool device__thread_send_msg(
+		enum bl_msg_type *sent_type)
+{
+	static bool calibrating;
+	union bl_msg_data *send_msg = device__msg_get_next_queued();
+	if (send_msg == NULL) {
+		return true;
+	}
+
+	if (send_msg->type == MSG_START_SPECIAL_CAL ||
+	    send_msg->type == MSG_START_SPECIAL_ACQ) {
+		bv_device_g.rec = device__open_recording(
+				send_msg->type == MSG_START_SPECIAL_CAL);
+		if (bv_device_g.rec == NULL) {
+			fprintf(stderr,
+				"Warning: Failed to open recording file.\n");
+		}
+
+		calibrating = (send_msg->type == MSG_START_SPECIAL_CAL);
+		device__msg_sent(send_msg);
+		return true;
+	}
+
+	if (bl_msg_write(bv_device_g.dev_fd, "Discovered device", send_msg)) {
+		*sent_type = send_msg->type;
+		if (send_msg->type == BL_MSG_START) {
+			if (!data_start(calibrating,
+					send_msg->start.frequency,
+					send_msg->start.src_mask)) {
+				/* TODO: If this fails, we'll block on
+				 * never clearing this message. */
+				return false;
+			}
+		}
+
+		if (bv_device_g.rec != NULL) {
+			bl_msg_yaml_print(bv_device_g.rec, send_msg);
+		}
+		bl_msg_yaml_print(stderr, send_msg);
+
+		device__msg_sent(send_msg);
+	}
+
+	return true;
+}
+
+/**
+ * Handle an incoming response message sent from the device.
+ *
+ * \param[in]  sent_type  The type of any outstanding sent message.
+ * \param[in]  recv_msg   The incoming response message to handle.
+ * \return BL_MSG__COUNT if the \ref recv_msg was a response to \ref sent_type,
+ *         or \ref sent_type otherwise.
+ */
+static enum bl_msg_type device__thread_receive_msg_response(
+		const enum bl_msg_type  *sent_type,
+		const union bl_msg_data *recv_msg)
+{
+	if (recv_msg->response.response_to == *sent_type) {
+		if (bv_device_g.rec != NULL) {
+			bl_msg_yaml_print(bv_device_g.rec, recv_msg);
+		}
+
+		switch (*sent_type) {
+		case BL_MSG_START:
+			if (recv_msg->response.error_code == BL_ERROR_NONE) {
+				device__set_state(DEVICE_STATE_ACTIVE);
+			} else {
+				data_finish();
+			}
+			break;
+
+		case BL_MSG_ABORT:
+			if (recv_msg->response.error_code == BL_ERROR_NONE) {
+				device__set_state(DEVICE_STATE_IDLE);
+				data_finish();
+
+				if (bv_device_g.rec != NULL) {
+					fclose(bv_device_g.rec);
+					bv_device_g.rec = NULL;
+				}
+			}
+			break;
+		default:
+			break;
+		}
+
+		bl_msg_yaml_print(stderr, recv_msg);
+		return BL_MSG__COUNT;
+	}
+
+	bl_msg_yaml_print(stderr, recv_msg);
+	return *sent_type;
+}
+
+/**
+ * Handle an incoming message sent from the device.
+ *
+ * \param[in,out]  sent_type  The type of any outstanding sent message.
+ *                            Returns BL_MSG__COUNT if the incoming message
+ *                            was a response to this type.
+ */
+static void device__thread_receive_msg(
+		enum bl_msg_type *sent_type)
+{
+	union bl_msg_data recv_msg;
+
+	if (bl_msg_read(bv_device_g.dev_fd, 100, &recv_msg)) {
+		switch (recv_msg.type) {
+		case BL_MSG_RESPONSE:
+			*sent_type = device__thread_receive_msg_response(
+					sent_type, &recv_msg);
+
+			break;
+		case BL_MSG_SAMPLE_DATA16:
+			data_handle_msg_u16(&recv_msg.sample_data);
+			if (bv_device_g.rec != NULL) {
+				bl_msg_yaml_print(bv_device_g.rec, &recv_msg);
+			}
+
+			break;
+		case BL_MSG_SAMPLE_DATA32:
+			data_handle_msg_u32(&recv_msg.sample_data);
+			if (bv_device_g.rec != NULL) {
+				bl_msg_yaml_print(bv_device_g.rec, &recv_msg);
+			}
+
+			break;
+		default:
+			fprintf(stderr, "Unexpected message from device:\n");
+			bl_msg_yaml_print(stderr, &recv_msg);
+		}
+	}
+}
+
+/**
+ * A separate thread for handling communication with the device.
+ *
+ * All of the messages sending and receiving happens in this thread.
+ * It also drives the data pipeline to pass new data into the data
+ * module.
+ *
+ * \param[in]  ctx  The device module global context.
+ * \return Device module global context on successful exit, or NULL on error.
+ */
+static void *device__thread(void *ctx)
+{
+	enum bl_msg_type sent_type = BL_MSG__COUNT;
+
+	if (ctx != &bv_device_g) {
+		return NULL;
+	}
+
+	while (bv_device_g.quit == false ) {
+		if (sent_type == BL_MSG__COUNT) {
+			/* Not already waiting for outstanding response. */
+			if (!device__thread_send_msg(&sent_type)) {
+				fprintf(stderr, "Fatal error\n");
+				return NULL;
+			}
+		}
+
+		if ((sent_type != BL_MSG__COUNT) ||
+		    (device__get_current_state() == DEVICE_STATE_ACTIVE)) {
+			/* Awaiting response to sent message,
+			 * or running an acquisition. */
+			device__thread_receive_msg(&sent_type);
+		}
+	}
+
+	return ctx;
+}
+
+/**
+ * Send a start indicator to the device thread.
+ *
+ * This is a notification that we are about to start a sequence of messages
+ * that should represent a recording, it is not a message to be sent itself.
+ *
+ * \param[in]  calibrate  Whether device is being configured for calibration.
+ * \return true if a message has been queued for sending to the device.
+ */
+static bool device__queue_msg_special_start_indicator(bool calibrate)
+{
+	union bl_msg_data *msg;
+
+	msg = device__msg_get_next_free();
+	if (msg == NULL) {
+		return false;
+	}
+
+	msg->type = calibrate ? MSG_START_SPECIAL_CAL : MSG_START_SPECIAL_ACQ;
+
+	device__msg_send(msg);
+	return true;
+}
+
+/**
+ * Turn device LED(s) on/off.
+ *
+ * When turning on, the LED mask is obtained from the main menu configuration.
+ *
+ * \param[in]  enable_lights  Whether the light(s) should be turned on or off.
+ * \return true if a message has been queued for sending to the device.
+ */
+static bool device__queue_msg_led(bool enable_lights)
+{
+	union bl_msg_data *msg;
+	uint16_t led_mask = 0;
+
+	if (enable_lights) {
+		led_mask = main_menu_conifg_get_led_mask();
+	}
+
+	msg = device__msg_get_next_free();
+	if (msg == NULL) {
+		return false;
+	}
+
+	msg->type = BL_MSG_LED;
+	msg->led.led_mask = led_mask;
+
+	device__msg_send(msg);
+	return true;
+}
+
+/**
+ * Configure a channel on the device.
+ *
+ * The config is obtained from the main menu configuration.
+ *
+ * \param[in]  channel    The channel to configure.
+ * \param[in]  calibrate  Whether device is being configured for calibration.
+ * \return true if a message has been queued for sending to the device.
+ */
+static bool device__queue_msg_channel_conf(
+		uint8_t channel,
+		bool    calibrate)
+{
+	union bl_msg_data *msg;
+	bool sample32 = main_menu_conifg_get_channel_sample32(channel);
+
+	msg = device__msg_get_next_free();
+	if (msg == NULL) {
+		return false;
+	}
+
+	if (calibrate) {
+		sample32 = true;
+	}
+
+	msg->type = BL_MSG_CHANNEL_CONF;
+	msg->channel_conf.channel  = channel;
+	msg->channel_conf.gain     = main_menu_conifg_get_channel_gain(channel);
+	msg->channel_conf.shift    = main_menu_conifg_get_channel_shift(channel);
+	msg->channel_conf.offset   = main_menu_conifg_get_channel_offset(channel);
+	msg->channel_conf.sample32 = sample32;
+
+	device__msg_send(msg);
+	return true;
+}
+
+/**
+ * Start acquisition on the device.
+ *
+ * The config is obtained from the main menu configuration.
+ *
+ * \return true if a message has been queued for sending to the device.
+ */
+static bool device__queue_msg_start(void)
+{
+	union bl_msg_data *msg;
+
+	msg = device__msg_get_next_free();
+	if (msg == NULL) {
+		return false;
+	}
+
+	msg->type = BL_MSG_START;
+	msg->start.frequency  = main_menu_conifg_get_frequency();
+	msg->start.oversample = main_menu_conifg_get_oversample();
+	msg->start.src_mask   = main_menu_conifg_get_source_mask();
+
+	device__msg_send(msg);
+	return true;
+}
+
+/**
+ * Abort acquisition on the device.
+ *
+ * \return true if a message has been queued for sending to the device.
+ */
+static bool device__queue_msg_abort(void)
+{
+	union bl_msg_data *msg;
+
+	msg = device__msg_get_next_free();
+	if (msg == NULL) {
+		return false;
+	}
+
+	msg->type = BL_MSG_ABORT;
+
+	device__msg_send(msg);
+	return true;
+}
+
+/**
+ * Configure all enabled channels on the device.
+ *
+ * The config is obtained from the main menu configuration.
+ *
+ * \param[in]  calibrate  Whether device is being configured for calibration.
+ * \return true if all messages have been queued for sending to the device.
+ */
+static bool device__queue_channel_conf_messages(bool calibrate)
+{
+	unsigned source_mask = main_menu_conifg_get_source_mask();
+
+	for (unsigned i = 0; i < BL_ACQ__SRC_COUNT; i++) {
+		if (source_mask & (1U << i)) {
+			if (!device__queue_msg_channel_conf(i, calibrate)) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+/* Exported function, documented in device.h */
+static bool device__start(
+		const char *ctx_string,
+		bool calibrate)
+{
+	if (!device__ensure_initialised(ctx_string)) {
+		return false;
+	}
+
+	if (!device__queue_msg_special_start_indicator(calibrate)) {
+		goto error;
+	}
+
+	if (!device__queue_msg_led(true)) {
+		goto error;
+	}
+
+	if (!device__queue_channel_conf_messages(calibrate)) {
+		goto error;
+	}
+
+	if (!device__queue_msg_start()) {
+		goto error;
+	}
+
+	return true;
+
+error:
+	data_finish();
+	return false;
+}
+
+/* Exported function, documented in device.h */
+bool device_calibrate_start(void)
+{
+	return device__start(__func__, true);
+}
+
+/* Exported function, documented in device.h */
+bool device_acquisition_start(void)
+{
+	return device__start(__func__, false);
+}
+
+/* Exported function, documented in device.h */
+bool device_stop()
+{
+	if (!device__is_initialised()) {
+		return false;
+	}
+
+	/* Don't check for DEVICE_STATE_ACTIVE state here.  The device may
+	 * have got out of sync, so it's always useful to be able to send
+	 * the abort message.
+	 */
+
+	if (!device__queue_msg_abort()) {
+		return false;
+	}
+
+	if (!device__queue_msg_led(false)) {
+		return false;
+	}
+
+	return true;
+}
+
+/* Exported function, documented in device.h */
+bool device_init(
+		const char *dev_path,
+		device_state_change_cb cb,
+		void *pw)
+{
+	int dev_fd;
+	int ret;
+
+	if (device__is_initialised()) {
+		fprintf(stderr, "%s: Device module is already initialised.\n",
+				__func__);
+		return false;
+	}
+
+	dev_fd = bl_device_open(dev_path);
+	if (dev_fd < 0) {
+		return false;
+	}
+
+	bv_device_g.dev_fd = dev_fd;
+	bv_device_g.cb = cb;
+	bv_device_g.pw = pw;
+
+	if (!device__set_state(DEVICE_STATE_IDLE)) {
+		memset(&bv_device_g.thread_id, 0,
+				sizeof(bv_device_g.thread_id));
+		bl_device_close(bv_device_g.dev_fd);
+		return false;
+	}
+
+	bv_device_g.quit = false;
+	ret = pthread_create(&bv_device_g.thread_id, NULL,
+			&device__thread, &bv_device_g);
+	if (ret != 0) {
+		memset(&bv_device_g.thread_id, 0,
+				sizeof(bv_device_g.thread_id));
+		bl_device_close(bv_device_g.dev_fd);
+		return false;
+	}
+
+	return true;
+}
+
+/* Exported function, documented in device.h */
+void device_fini(void)
+{
+	void *thread_ret = NULL;
+	int ret;
+
+	if (!device__is_initialised()) {
+		return;
+	}
+
+	if (locked_uint_is_equal(&bv_device_g.state, DEVICE_STATE_ACTIVE)) {
+		device_stop();
+	}
+
+	while (device__msg_get_next_queued() != NULL) {
+		/* Ensure the stop messages are sent before quitting. */
+	}
+
+	bv_device_g.quit = true;
+	ret = pthread_join(bv_device_g.thread_id, &thread_ret);
+	if (ret != 0) {
+		fprintf(stderr, "Error: Failed to join device thread (%i)",
+				ret);
+	}
+	device__set_state(DEVICE_STATE_NONE);
+
+	memset(&bv_device_g.thread_id, 0,
+			sizeof(bv_device_g.thread_id));
+
+	if (bv_device_g.rec != NULL) {
+		fclose(bv_device_g.rec);
+		bv_device_g.rec = NULL;
+	}
+
+	bl_device_close(bv_device_g.dev_fd);
+	bv_device_g.dev_fd = 0;
+	bv_device_g.cb = NULL;
+	bv_device_g.pw = NULL;
+}

--- a/bloodview/src/device.h
+++ b/bloodview/src/device.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BV_DEVICE_H
+#define BV_DEVICE_H
+
+typedef enum device_state {
+	DEVICE_STATE_NONE,
+	DEVICE_STATE_IDLE,
+	DEVICE_STATE_ACTIVE,
+} device_state_t;
+
+/**
+ * Callback for notification of device state changes.
+ *
+ * \param[in]  pw     Client private context data.
+ * \param[in]  state  The state that we've changed to.
+ */
+typedef void (* device_state_change_cb)(
+		void *pw, device_state_t state);
+
+/**
+ * Initialise the device module.
+ *
+ * This will try to connect to a device, and fail if it can't.
+ *
+ * \param[in]  device Node to open, or NULL for device discovery.
+ * \param[in]  cb     Callback to handle 
+ * \param[in]  pw     Client private context data.
+ * \return true on success, or false on error.
+ */
+bool device_init(
+		const char *dev_path,
+		device_state_change_cb cb,
+		void *pw);
+
+/**
+ * Finalise the device module.
+ */
+void device_fini(
+		void);
+
+/**
+ * Start calibration.
+ *
+ * \return true on success, or false on error.
+ */
+bool device_calibrate_start(
+		void);
+
+/**
+ * Start acquisition.
+ *
+ * \return true on success, or false on error.
+ */
+bool device_acquisition_start(
+		void);
+
+/**
+ * Stop acquisition or calibration.
+ *
+ * \return true on success, or false on error.
+ */
+bool device_stop(
+		void);
+
+#endif /* BV_DEVICE_H */

--- a/bloodview/src/graph.c
+++ b/bloodview/src/graph.c
@@ -1,0 +1,367 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include <pthread.h>
+
+#include "graph.h"
+
+/** Extra sample slots per graph */
+#define GRAPH_EXCESS 1024
+
+#define Y_SCALE_DATUM (1u << 10)
+#define Y_SCALE_STEP  (1u <<  4)
+
+struct graph {
+	int32_t *data;
+
+	unsigned max; /**< Maximum number of samples \ref data can store. */
+	unsigned len; /**< Number of available samples (<= \ref max). */
+	unsigned pos; /**< Position of next sample to insert. */
+	unsigned ren; /**< Last rendered sample. */
+
+	uint64_t scale;
+};
+
+/** Graph global context. */
+static struct {
+	struct graph *channel;
+
+	unsigned count;
+	unsigned current;
+	bool     single;
+
+	pthread_mutex_t lock;
+} graph_g;
+
+/* Exported function, documented in graph.h */
+void graph_fini(void)
+{
+	pthread_mutex_lock(&graph_g.lock);
+
+	if (graph_g.channel != NULL) {
+		for (unsigned i = 0; i < graph_g.count; i++) {
+			free(graph_g.channel[i].data);
+			memset(&graph_g.channel[i], 0,
+					sizeof(graph_g.channel[i]));
+		}
+		free(graph_g.channel);
+	}
+
+	graph_g.channel = NULL;
+	graph_g.count   = 0;
+
+	pthread_mutex_unlock(&graph_g.lock);
+}
+
+/* Exported function, documented in graph.h */
+bool graph_init(void)
+{
+	return true;
+}
+
+/* Exported function, documented in graph.h */
+bool graph_create(unsigned idx, unsigned freq)
+{
+	struct graph *g;
+
+	if (idx >= graph_g.count) {
+		struct graph *channels;
+		unsigned count = idx + 1;
+		size_t size = sizeof(*channels);
+		unsigned old_count = graph_g.count;
+
+		channels = realloc(graph_g.channel, count * size);
+		if (channels == NULL) {
+			return false;
+		}
+
+		memset(&channels[old_count], 0, (count - old_count) * size);
+
+		graph_g.channel = channels;
+		graph_g.count   = count;
+	}
+
+	g = graph_g.channel + idx;
+
+	if (g->data == NULL) {
+		unsigned max = GRAPH_EXCESS + freq * 32;
+		g->data = malloc(max * sizeof(*g->data));
+		if (g->data == NULL) {
+			return false;
+		}
+		g->max = max;
+
+		g->scale = Y_SCALE_DATUM / 8;
+	} else {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Ensure that a graph at the given index exists.
+ *
+ * \param[in]  idx  Index to check.
+ * \return true if the graph exists, otherwise false.
+ */
+static bool graph__ensure(unsigned idx)
+{
+	if ((idx >= graph_g.count) || graph_g.channel[idx].data == NULL) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Increment the position pointer of a graph object.
+ *
+ * \param[in]  graph  The graph object.
+ * \param[in]  pos    The position to increment.
+ * \return the new position.
+ */
+static inline unsigned graph_pos_increment(
+		const struct graph *graph,
+		unsigned pos)
+{
+	pos++;
+
+	if (pos == graph->max) {
+		pos = 0;
+	}
+
+	return pos;
+}
+
+/**
+ * Decrement the position pointer of a graph object.
+ *
+ * \param[in]  graph  The graph object.
+ * \param[in]  pos    The position to decrement.
+ * \return the new position.
+ */
+static inline unsigned graph_pos_decrement(
+		const struct graph *graph,
+		unsigned pos)
+{
+	if (pos == 0) {
+		pos = graph->max - 1;
+	} else {
+		pos--;
+	}
+
+	return pos;
+}
+
+/* Exported function, documented in graph.h */
+bool graph_data_add(unsigned idx, int32_t value)
+{
+	struct graph *g = graph_g.channel + idx;
+
+	if (!graph__ensure(idx)) {
+		return false;
+	}
+
+	g->data[g->pos] = value;
+
+	if (g->len < g->max) {
+		g->len++;
+	}
+
+	g->pos = graph_pos_increment(g, g->pos);
+
+	return true;
+}
+
+/**
+ * Render a graph.
+ *
+ * \param[in]  ren    The SDL renderer.
+ * \param[in]  idx    The graph index to render.
+ * \param[in]  r      The rectangle containing the graphs.
+ * \param[in]  y_off  The vertical offset at which to render the graph.
+ */
+void graph__render(
+		SDL_Renderer   *ren,
+		unsigned        idx,
+		const SDL_Rect *r,
+		unsigned        y_off)
+{
+	unsigned y_next;
+	unsigned y_prev;
+	unsigned pos_next;
+	const unsigned step = 1;
+	struct graph *g = graph_g.channel + idx;
+
+	if (idx >= graph_g.count) {
+		return;
+	}
+
+	SDL_SetRenderDrawColor(ren, 255, 255, 255, SDL_ALPHA_OPAQUE);
+
+	y_off += r->y;
+	pos_next = graph_pos_decrement(g, g->pos);
+	y_next = y_off + g->data[pos_next] * g->scale / Y_SCALE_DATUM;
+
+	for (unsigned x = r->x + r->w; x > (unsigned)r->x; x--) {
+		for (unsigned i = 0; i < step - 1; i++) {
+			pos_next = graph_pos_decrement(g, pos_next);
+			y_prev = y_next;
+			y_next = y_off + g->data[pos_next] * g->scale / Y_SCALE_DATUM;
+			SDL_RenderDrawLine(ren, x, y_prev, x, y_next);
+		}
+
+		pos_next = graph_pos_decrement(g, pos_next);
+		y_prev = y_next;
+		y_next = y_off + g->data[pos_next] * g->scale / Y_SCALE_DATUM;
+		SDL_RenderDrawLine(ren, x, y_prev, x - 1, y_next);
+	}
+}
+
+/* Exported function, documented in graph.h */
+void graph_render(
+		SDL_Renderer   *ren,
+		const SDL_Rect *r)
+{
+	SDL_Rect graph_rect = *r;
+
+	pthread_mutex_lock(&graph_g.lock);
+
+	if ((graph_g.channel == NULL) ||
+	    (graph_g.count == 0)) {
+		goto cleanup;
+	}
+
+	if (graph_g.single) {
+		graph__render(ren, graph_g.current, r, r->h / 2);
+		goto cleanup;
+	}
+
+	graph_rect.h = r->h / graph_g.count;
+	graph_rect.y = (r->h - graph_rect.h * graph_g.count) / 2 +
+			graph_rect.h * graph_g.current;
+
+	SDL_SetRenderDrawColor(ren, 32, 32, 32, SDL_ALPHA_OPAQUE);
+	SDL_RenderFillRect(ren, &graph_rect);
+
+	graph_rect.y = (r->h - graph_rect.h * graph_g.count) / 2;
+	for (unsigned i = 0; i < graph_g.count; i++) {
+		graph__render(ren, i, &graph_rect, graph_rect.h / 2);
+		graph_rect.y += graph_rect.h;
+	}
+
+cleanup:
+	pthread_mutex_unlock(&graph_g.lock);
+}
+
+/* Exported function, documented in graph.h */
+static bool graph__y_scale_inc(unsigned idx)
+{
+	struct graph *g = graph_g.channel + idx;
+	unsigned old = g->scale;
+
+	if (idx >= graph_g.count) {
+		return false;
+	}
+
+	g->scale += Y_SCALE_STEP;
+
+	if (g->scale > Y_SCALE_DATUM * 8) {
+		g->scale = Y_SCALE_DATUM * 8;
+	}
+
+	return (g->scale != old);
+}
+
+/* Exported function, documented in graph.h */
+static bool graph__y_scale_dec(unsigned idx)
+{
+	struct graph *g = graph_g.channel + idx;
+	unsigned old = g->scale;
+
+	if (idx >= graph_g.count) {
+		return false;
+	}
+
+	if (g->scale < Y_SCALE_STEP) {
+		g->scale = 1;
+	} else {
+		g->scale -= Y_SCALE_STEP;
+	}
+
+	return (g->scale != old);
+}
+
+/* Exported function, documented in graph.h */
+bool graph_handle_input(
+		const SDL_Event *event)
+{
+	bool handled = false;
+
+	pthread_mutex_lock(&graph_g.lock);
+
+	if ((graph_g.channel == NULL) || (graph_g.count == 0)) {
+		handled = false;
+		goto cleanup;
+	}
+
+	switch (event->type) {
+	case SDL_KEYDOWN:
+		switch (event->key.keysym.sym) {
+		case SDLK_UP:
+			handled = graph__y_scale_inc(graph_g.current);
+			break;
+
+		case SDLK_DOWN:
+			handled = graph__y_scale_dec(graph_g.current);
+			break;
+
+		case SDLK_PAGEUP:
+			if (graph_g.current == 0) {
+				graph_g.current = graph_g.count - 1;
+			} else {
+				graph_g.current--;
+			}
+			handled = true;
+			break;
+
+		case SDLK_PAGEDOWN:
+			graph_g.current++;
+			if (graph_g.current == graph_g.count) {
+				graph_g.current = 0;
+			}
+			handled = true;
+			break;
+
+		case SDLK_SPACE: /* Fall though */
+		case SDLK_RETURN:
+			graph_g.single = !graph_g.single;
+			handled = true;
+			break;
+		}
+		break;
+	}
+
+cleanup:
+	pthread_mutex_unlock(&graph_g.lock);
+	return handled;
+}

--- a/bloodview/src/graph.h
+++ b/bloodview/src/graph.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BV_GRAPH_H
+#define BV_GRAPH_H
+
+#include <SDL2/SDL.h>
+
+/**
+ * Initialise the graph module.
+ *
+ * \return true on success or false on failure.
+ */
+bool graph_init(void);
+
+/**
+ * Finalise the graph module.
+ */
+void graph_fini(void);
+
+/**
+ * Create a graph at given index.
+ *
+ * \param[in]  idx   Graph index to create.
+ * \param[in]  freq  The sampling frequency used for the graph.
+ * \return true on success, or false on errer.
+ */
+bool graph_create(unsigned idx, unsigned freq);
+
+/**
+ * Add a sample to a graph.
+ *
+ * \param[in]  g_idx  Index of the graph to add sample to.
+ * \param[in]  value  Sample to add to graph.
+ * \return true on success, false on error.
+ */
+bool graph_data_add(unsigned g_idx, int32_t value);
+
+/**
+ * Render all the graphs
+ *
+ * \param[in]  ren  The SDL renderer.
+ * \param[in]  r    The rectangle containing the graphs.
+ */
+void graph_render(
+		SDL_Renderer   *ren,
+		const SDL_Rect *r);
+
+/**
+ * Handle an input event
+ *
+ * \param[in]  event  The SDL renderer.
+ * \return true if the event was handled, or false otherwise.
+ */
+bool graph_handle_input(
+		const SDL_Event *event);
+
+#endif /* BV_GRAPH_H */

--- a/bloodview/src/main-menu.c
+++ b/bloodview/src/main-menu.c
@@ -1,0 +1,925 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ctype.h>
+#include <assert.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "../../src/acq.h"
+#include "../../src/util.h"
+
+#include "sdl-tk/widget.h"
+
+#include "sdl-tk/widget/menu.h"
+#include "sdl-tk/widget/input.h"
+#include "sdl-tk/widget/action.h"
+#include "sdl-tk/widget/toggle.h"
+
+#include "util.h"
+#include "bloodview.h"
+#include "main-menu.h"
+
+/** List of widget types used in the main menu. */
+enum widget_type {
+	WIDGET_TYPE_MENU,
+	WIDGET_TYPE_INPUT,
+	WIDGET_TYPE_ACTION,
+	WIDGET_TYPE_TOGGLE,
+};
+
+/** Main menu widget descriptor. */
+struct main_menu_widget_desc {
+	enum widget_type type;
+	const char *title;
+	union {
+		struct main_menu_widget_desc_menu {
+			const struct main_menu_widget_desc *entries;
+			unsigned count;
+		} menu;
+		struct main_menu_widget_desc_input {
+			const sdl_tk_widget_input_cb cb;
+			const char *initial;
+		} input;
+		struct main_menu_widget_desc_action {
+			const sdl_tk_widget_action_cb cb;
+			void *pw;
+		} action;
+		struct main_menu_widget_desc_toggle {
+			bool initial;
+		} toggle;
+	};
+};
+
+/** Current configuration for LEDs. */
+struct main_menu_config_leds {
+	uint8_t leds[BL_LED_COUNT];
+};
+
+/** Current configuration for a channel. */
+struct main_menu_config_channel {
+	unsigned gain;
+	unsigned offset;
+	unsigned shift;
+	bool     sample32;
+
+	struct sdl_tk_widget *widget_shift;
+	struct sdl_tk_widget *widget_offset;
+};
+
+/** Current acquisition configuration. */
+struct main_menu_config_acq_params {
+	unsigned frequency;
+	unsigned oversample;
+	uint8_t  sources[BL_ACQ__SRC_COUNT];
+};
+
+/** Current filter configuration. */
+struct main_menu_config_filter {
+	uint8_t normalise_enable;
+	double  normalise;
+
+	uint8_t ac_denoise_enable;
+	double  ac_denoise;
+
+	struct sdl_tk_widget *widget_normalise;
+	struct sdl_tk_widget *widget_ac_denoise;
+};
+
+/** Main menu configuration entries. */
+struct main_menu_config {
+	struct main_menu_config_acq_params acq;
+	struct main_menu_config_channel channel[BL_ACQ__SRC_COUNT];
+	struct main_menu_config_leds led;
+	struct main_menu_config_filter filter;
+
+	struct sdl_tk_widget *widget_cal;
+	struct sdl_tk_widget *widget_acq;
+	struct sdl_tk_widget *widget_stop;
+};
+
+/** Bloodview main menu configuration context. */
+static struct main_menu_config config;
+
+/**
+ * Callback for the toggle widgets.
+ *
+ * \param[in]  pw         Client private context data.
+ * \param[in]  new_value  New input widget value.
+ */
+static void main_menu_toggle_cb(
+		void *pw,
+		bool  new_value)
+{
+	uint8_t *value = pw;
+
+	if (value == &config.filter.normalise_enable) {
+		sdl_tk_widget_enable(
+				config.filter.widget_normalise,
+				new_value);
+
+	} else if (value == &config.filter.ac_denoise_enable) {
+		sdl_tk_widget_enable(
+				config.filter.widget_ac_denoise,
+				new_value);
+	}
+
+	*value = new_value;
+}
+
+/**
+ * Callback for input widget change notification and validation.
+ *
+ * \param[in]  pw         Client private context data.
+ * \param[in]  new_value  New input widget value.
+ * \return true to accept the new value. false to reject it.
+ */
+bool main_menu_numerical_input_cb(
+		void       *pw,
+		const char *new_value)
+{
+	unsigned *widget_value = pw;
+	size_t len = strlen(new_value);
+
+	for (unsigned i = 0; i < len; i++) {
+		if (isdigit(new_value[i]) == false) {
+			return false;
+		}
+	}
+
+	return util_read_unsigned(new_value, widget_value);
+}
+
+/**
+ * Callback for input widget change notification and validation.
+ *
+ * \param[in]  pw         Client private context data.
+ * \param[in]  new_value  New input widget value.
+ * \return true to accept the new value. false to reject it.
+ */
+bool main_menu_double_input_cb(
+		void       *pw,
+		const char *new_value)
+{
+	double *widget_value = pw;
+	size_t len = strlen(new_value);
+
+	for (unsigned i = 0; i < len; i++) {
+		if (isdigit(new_value[i]) == false &&
+		    new_value[i] != '.' &&
+		    new_value[i] != ',') {
+			return false;
+		}
+	}
+
+	return util_read_double(new_value, widget_value);
+}
+
+/* Filter menu entries/ */
+enum {
+	FILTER_VALUE_NORMALISE,
+	FILTER_VALUE_AC_DENOISE,
+	FILTER_ENABLE_NORMALISE,
+	FILTER_ENABLE_AC_DENOISE,
+};
+
+/**
+ * Filter setup menu.
+ */
+static const struct main_menu_widget_desc bl_menu_config_filter_entries[] = {
+	[FILTER_VALUE_NORMALISE] = {
+		.type  = WIDGET_TYPE_INPUT,
+		.title = "Normalisation frequency (Hz)",
+		.input = {
+			.initial = "0.5",
+			.cb = main_menu_double_input_cb,
+		},
+	},
+	[FILTER_VALUE_AC_DENOISE] = {
+		.type  = WIDGET_TYPE_INPUT,
+		.title = "AC denoise frequency (Hz)",
+		.input = {
+			.initial = "50",
+			.cb = main_menu_double_input_cb,
+		},
+	},
+	[FILTER_ENABLE_NORMALISE] = {
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Normalisation",
+		.toggle = {
+			.initial = true,
+		},
+	},
+	[FILTER_ENABLE_AC_DENOISE] = {
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "AC denoise",
+		.toggle = {
+			.initial = true,
+		},
+	},
+};
+
+/**
+ * LED selection menu.
+ */
+static const struct main_menu_widget_desc bl_menu_config_led_entries[BL_LED_COUNT] = {
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Blue (470nm)",
+	},
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Green (528nm)",
+		.toggle = {
+			.initial = true,
+		},
+	},
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Yellow (570nm)",
+	},
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Orange (590nm)",
+	},
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Orange (612nm)",
+	},
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Red (638nm)",
+	},
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Red (660nm)",
+	},
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Red (740nm)",
+	},
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Infrared (850nm)",
+	},
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Infrared (880nm)",
+	},
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Infrared (940nm)",
+	},
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Infrared (1040nm)",
+	},
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Infrared (1200nm)",
+	},
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Infrared (1450nm)",
+	},
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Infrared (1550nm)",
+	},
+	{
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Infrared (1650nm)",
+	},
+};
+
+/** Channel config menu entries. */
+enum {
+	CHAN_GAIN,
+	CHAN_OFFSET,
+	CHAN_SHIFT,
+	CHAN_32BIT,
+};
+
+/**
+ * Channel configuration menu.
+ */
+static const struct main_menu_widget_desc bl_menu_config_chan_c_entries[] = {
+	[CHAN_GAIN] = {
+		.type  = WIDGET_TYPE_INPUT,
+		.title = "Gain",
+		.input = {
+			.initial = "1",
+			.cb = main_menu_numerical_input_cb,
+		},
+	},
+	[CHAN_OFFSET] = {
+		.type  = WIDGET_TYPE_INPUT,
+		.title = "Offset",
+		.input = {
+			.initial = "0",
+			.cb = main_menu_numerical_input_cb,
+		},
+	},
+	[CHAN_SHIFT] = {
+		.type  = WIDGET_TYPE_INPUT,
+		.title = "Shift",
+		.input = {
+			.initial = "0",
+			.cb = main_menu_numerical_input_cb,
+		},
+	},
+	[CHAN_32BIT] = {
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "32-bit samples",
+	},
+};
+
+/**
+ * Channel configuration list.
+ */
+static const struct main_menu_widget_desc bl_menu_config_chan_entries[] = {
+	[BL_ACQ_PD1] = {
+		.type  = WIDGET_TYPE_MENU,
+		.title = "Photodiode 1",
+		.menu  = {
+			.entries = bl_menu_config_chan_c_entries,
+			.count   = BL_ARRAY_LEN(bl_menu_config_chan_c_entries),
+		},
+	},
+	[BL_ACQ_PD2] = {
+		.type  = WIDGET_TYPE_MENU,
+		.title = "Photodiode 2",
+		.menu  = {
+			.entries = bl_menu_config_chan_c_entries,
+			.count   = BL_ARRAY_LEN(bl_menu_config_chan_c_entries),
+		},
+	},
+	[BL_ACQ_PD3] = {
+		.type  = WIDGET_TYPE_MENU,
+		.title = "Photodiode 3",
+		.menu  = {
+			.entries = bl_menu_config_chan_c_entries,
+			.count   = BL_ARRAY_LEN(bl_menu_config_chan_c_entries),
+		},
+	},
+	[BL_ACQ_PD4] = {
+		.type  = WIDGET_TYPE_MENU,
+		.title = "Photodiode 4",
+		.menu  = {
+			.entries = bl_menu_config_chan_c_entries,
+			.count   = BL_ARRAY_LEN(bl_menu_config_chan_c_entries),
+		},
+	},
+	[BL_ACQ_3V3] = {
+		.type  = WIDGET_TYPE_MENU,
+		.title = "3.3 Volts",
+		.menu  = {
+			.entries = bl_menu_config_chan_c_entries,
+			.count   = BL_ARRAY_LEN(bl_menu_config_chan_c_entries),
+		},
+	},
+	[BL_ACQ_5V0] = {
+		.type  = WIDGET_TYPE_MENU,
+		.title = "5.0 Volts",
+		.menu  = {
+			.entries = bl_menu_config_chan_c_entries,
+			.count   = BL_ARRAY_LEN(bl_menu_config_chan_c_entries),
+		},
+	},
+	[BL_ACQ_TMP] = {
+		.type  = WIDGET_TYPE_MENU,
+		.title = "Temperature",
+		.menu  = {
+			.entries = bl_menu_config_chan_c_entries,
+			.count   = BL_ARRAY_LEN(bl_menu_config_chan_c_entries),
+		},
+	},
+};
+
+/**
+ * Channel selection menu.
+ */
+static const struct main_menu_widget_desc bl_menu_config_acq_sources_entries[] = {
+	[BL_ACQ_PD1] = {
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Photodiode 1",
+		.toggle = {
+			.initial = true,
+		},
+	},
+	[BL_ACQ_PD2] = {
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Photodiode 2",
+		.toggle = {
+			.initial = true,
+		},
+	},
+	[BL_ACQ_PD3] = {
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Photodiode 3",
+		.toggle = {
+			.initial = true,
+		},
+	},
+	[BL_ACQ_PD4] = {
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Photodiode 4",
+		.toggle = {
+			.initial = true,
+		},
+	},
+	[BL_ACQ_3V3] = {
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "3.3 Volts",
+	},
+	[BL_ACQ_5V0] = {
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "5.0 Volts",
+	},
+	[BL_ACQ_TMP] = {
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Temperature",
+	},
+};
+
+/** Acquisition config menu entries. */
+enum {
+	ACQ_FREQ,
+	ACQ_OVER,
+	ACQ_SRC,
+};
+
+/**
+ * Acquisition configuration menu.
+ */
+static const struct main_menu_widget_desc bl_menu_config_acq_entries[] = {
+	[ACQ_FREQ] = {
+		.type  = WIDGET_TYPE_INPUT,
+		.title = "Frequency (Hz)",
+		.input = {
+			.initial = "250",
+			.cb = main_menu_numerical_input_cb,
+		},
+	},
+	[ACQ_OVER] = {
+		.type  = WIDGET_TYPE_INPUT,
+		.title = "Oversample",
+		.input = {
+			.initial = "512",
+			.cb = main_menu_numerical_input_cb,
+		},
+	},
+	[ACQ_SRC]  = {
+		.type  = WIDGET_TYPE_MENU,
+		.title = "Sources",
+		.menu  = {
+			.entries = bl_menu_config_acq_sources_entries,
+			.count   = BL_ARRAY_LEN(bl_menu_config_acq_sources_entries),
+		},
+	},
+};
+
+/**
+ * Configuration menu.
+ */
+static const struct main_menu_widget_desc bl_menu_config_entries[] = {
+	{
+		.type  = WIDGET_TYPE_MENU,
+		.title = "Acquisition",
+		.menu  = {
+			.entries = bl_menu_config_acq_entries,
+			.count   = BL_ARRAY_LEN(bl_menu_config_acq_entries),
+		},
+	},
+	{
+		.type  = WIDGET_TYPE_MENU,
+		.title = "Channels",
+		.menu  = {
+			.entries = bl_menu_config_chan_entries,
+			.count   = BL_ARRAY_LEN(bl_menu_config_chan_entries),
+		},
+	},
+	{
+		.type  = WIDGET_TYPE_MENU,
+		.title = "LEDs",
+		.menu  = {
+			.entries = bl_menu_config_led_entries,
+			.count   = BL_ARRAY_LEN(bl_menu_config_led_entries),
+		},
+	},
+	{
+		.type  = WIDGET_TYPE_MENU,
+		.title = "Filtering",
+		.menu  = {
+			.entries = bl_menu_config_filter_entries,
+			.count   = BL_ARRAY_LEN(bl_menu_config_filter_entries),
+		},
+	},
+};
+
+enum {
+	MAIN_CAL,
+	MAIN_ACQ,
+	MAIN_STOP,
+	MAIN_CONFIG,
+	MAIN_QUIT,
+};
+
+/**
+ * Main menu listing.
+ */
+static const struct main_menu_widget_desc bl_menu_main_entries[] = {
+	[MAIN_CAL]    = {
+		.type   = WIDGET_TYPE_ACTION,
+		.title  = "Calibrate",
+		.action = {
+			.cb = bloodview_start_cal_cb,
+		},
+	},
+	[MAIN_ACQ]    = {
+		.type   = WIDGET_TYPE_ACTION,
+		.title  = "Acquisition",
+		.action = {
+			.cb = bloodview_start_acq_cb,
+		},
+	},
+	[MAIN_STOP]   = {
+		.type   = WIDGET_TYPE_ACTION,
+		.title  = "Stop",
+		.action = {
+			.cb = bloodview_stop_cb,
+		},
+	},
+	[MAIN_CONFIG] = {
+		.type  = WIDGET_TYPE_MENU,
+		.title = "Config",
+		.menu  = {
+			.entries = bl_menu_config_entries,
+			.count   = BL_ARRAY_LEN(bl_menu_config_entries),
+		},
+	},
+	[MAIN_QUIT]   = {
+		.type   = WIDGET_TYPE_ACTION,
+		.title  = "Quit",
+		.action = {
+			.cb = bloodview_quit_cb,
+		},
+	},
+};
+
+/**
+ * Main menu widget.
+ */
+static const struct main_menu_widget_desc bl_main_menu = {
+	.type  = WIDGET_TYPE_MENU,
+	.title = "Bloodlight Viewer",
+	.menu  = {
+		.entries = bl_menu_main_entries,
+		.count   = BL_ARRAY_LEN(bl_menu_main_entries),
+	},
+};
+
+/**
+ * Get the config private word for a main menu entry.
+ *
+ * \param[in]  desc   Menu descriptor for entry's parent menu.
+ * \param[in]  entry  The entry index to create a widget for.
+ * \return config private word for the menu entry, or NULL if none.
+ */
+static void *get_config_pw_for_entry(
+		const struct main_menu_widget_desc *desc,
+		unsigned entry)
+{
+	static unsigned chan_entry;
+	const struct main_menu_widget_desc *entries = desc->menu.entries;
+
+	if (entries == bl_menu_config_acq_entries) {
+		switch (entry) {
+		case ACQ_FREQ: return &config.acq.frequency;
+		case ACQ_OVER: return &config.acq.oversample;
+		}
+
+	} else if (entries == bl_menu_config_acq_sources_entries) {
+		return &config.acq.sources[entry];
+
+	} else if (entries == bl_menu_config_chan_entries) {
+		chan_entry = entry;
+
+	} else if (entries == bl_menu_config_chan_c_entries) {
+		switch (entry) {
+		case CHAN_GAIN:   return &config.channel[chan_entry].gain;
+		case CHAN_OFFSET: return &config.channel[chan_entry].offset;
+		case CHAN_SHIFT:  return &config.channel[chan_entry].shift;
+		case CHAN_32BIT:  return &config.channel[chan_entry].sample32;
+		}
+
+	} else if (entries == bl_menu_config_led_entries) {
+		return &config.led.leds[entry];
+	} else if (entries == bl_menu_config_filter_entries) {
+		switch (entry) {
+		case FILTER_VALUE_NORMALISE:   return &config.filter.normalise;
+		case FILTER_VALUE_AC_DENOISE:  return &config.filter.ac_denoise;
+		case FILTER_ENABLE_NORMALISE:  return &config.filter.normalise_enable;
+		case FILTER_ENABLE_AC_DENOISE: return &config.filter.ac_denoise_enable;
+		}
+	}
+
+	return NULL;
+}
+
+/**
+ * Record any widgets we might need to update the values of.
+ *
+ * \param[in]  desc   Menu descriptor for entry's parent menu.
+ * \param[in]  entry  The menu entry index widget is for.
+ * \return config private word for the menu entry, or NULL if none.
+ */
+static struct sdl_tk_widget **main_menu_record_widget(
+		const struct main_menu_widget_desc *desc,
+		unsigned entry)
+{
+	static unsigned chan_entry;
+	const struct main_menu_widget_desc *entries = desc->menu.entries;
+
+	if (entries == bl_menu_config_chan_entries) {
+		chan_entry = entry;
+
+	} else if (entries == bl_menu_config_chan_c_entries) {
+		switch (entry) {
+		case CHAN_OFFSET:
+			return &config.channel[chan_entry].widget_offset;
+		case CHAN_SHIFT:
+			return &config.channel[chan_entry].widget_shift;
+		default:
+			break;
+		}
+	} else if (entries == bl_menu_main_entries) {
+		switch (entry) {
+		case MAIN_CAL:  return &config.widget_cal;
+		case MAIN_ACQ:  return &config.widget_acq;
+		case MAIN_STOP: return &config.widget_stop;
+		}
+
+	} else if (entries == bl_menu_config_filter_entries) {
+		switch (entry) {
+		case FILTER_VALUE_NORMALISE:  return &config.filter.widget_normalise;
+		case FILTER_VALUE_AC_DENOISE: return &config.filter.widget_ac_denoise;
+		}
+	}
+
+	return NULL;
+}
+
+/**
+ * Main menu entry creation callback.
+ *
+ * \param[in]  parent  The widget currently being created.
+ * \param[in]  entry   The entry index to create a widget for.
+ * \param[in]  pw      Client private context data.
+ * \return the created sdl-tk widget for the menu entry or NULL on error.
+ */
+static struct sdl_tk_widget *desc_menu_create_cb(
+		struct sdl_tk_widget *parent,
+		unsigned entry,
+		void *pw)
+{
+	const struct main_menu_widget_desc *menu_desc = pw;
+	const struct main_menu_widget_desc *desc;
+	struct sdl_tk_widget **widget_record;
+	struct sdl_tk_widget *widget = NULL;
+	void *entry_pw;
+
+	assert(menu_desc->type == WIDGET_TYPE_MENU);
+
+	desc = &menu_desc->menu.entries[entry];
+
+	widget_record = main_menu_record_widget(menu_desc, entry);
+	entry_pw = get_config_pw_for_entry(menu_desc, entry);
+
+	switch (desc->type) {
+	case WIDGET_TYPE_MENU:
+		widget = sdl_tk_widget_menu_create(
+				parent,
+				desc->title,
+				desc->menu.count,
+				desc_menu_create_cb,
+				(void *) desc);
+		break;
+
+	case WIDGET_TYPE_INPUT:
+		widget = sdl_tk_widget_input_create(
+				parent,
+				desc->title,
+				desc->input.initial,
+				desc->input.cb,
+				entry_pw);
+		break;
+
+	case WIDGET_TYPE_ACTION:
+		widget = sdl_tk_widget_action_create(
+				parent,
+				desc->title,
+				desc->action.cb,
+				desc->action.pw);
+		break;
+
+	case WIDGET_TYPE_TOGGLE:
+		widget = sdl_tk_widget_toggle_create(
+				parent,
+				desc->title,
+				desc->toggle.initial,
+				main_menu_toggle_cb,
+				entry_pw);
+		break;
+
+	default:
+		fprintf(stderr, "Error: Unknown entry type (%i) "
+				"in main menu construction.\n",
+				(int) desc->type);
+		break;
+	}
+
+	if (widget_record != NULL) {
+		*widget_record = widget;
+	}
+
+	return widget;
+}
+
+/* Exported function, documented in main-menu.h */
+struct sdl_tk_widget *main_menu_create(void)
+{
+	struct sdl_tk_widget *widget;
+	assert(bl_main_menu.type == WIDGET_TYPE_MENU);
+
+	widget = sdl_tk_widget_menu_create(
+			NULL,
+			bl_main_menu.title,
+			bl_main_menu.menu.count,
+			desc_menu_create_cb,
+			(void *) &bl_main_menu);
+	if (widget == NULL) {
+		fprintf(stderr, "Error: Failed to create main menu.\n");
+	}
+
+	return widget;
+}
+
+/* Exported interface, documented in main-menu.h */
+uint16_t main_menu_conifg_get_led_mask(void)
+{
+	const uint16_t led_count = BL_LED_COUNT;
+	static const uint8_t mapping[BL_LED_COUNT] = {
+		15, 14, 13, 12, 11, 10,  9,  8,
+		 0,  1,  2,  3,  4,  5,  6,  7,
+	};
+	uint16_t led_mask = 0;
+
+	for (unsigned i = 0; i < led_count; i++) {
+		if (config.led.leds[i] != 0) {
+			led_mask |= 1U << mapping[i];
+		}
+	}
+
+	return led_mask;
+}
+
+/* Exported interface, documented in main-menu.h */
+uint16_t main_menu_conifg_get_source_mask(void)
+{
+	const uint16_t src_count = BL_ARRAY_LEN(
+			bl_menu_config_acq_sources_entries);
+	uint16_t src_mask = 0;
+
+	for (unsigned i = 0; i < src_count; i++) {
+		if (config.acq.sources[i] != 0) {
+			src_mask |= 1U << i;
+		}
+	}
+
+	return src_mask;
+}
+
+/* Exported interface, documented in main-menu.h */
+uint16_t main_menu_conifg_get_frequency(void)
+{
+	return config.acq.frequency;
+}
+
+/* Exported interface, documented in main-menu.h */
+uint32_t main_menu_conifg_get_oversample(void)
+{
+	return config.acq.oversample;
+}
+
+/* Exported interface, documented in main-menu.h */
+uint8_t main_menu_conifg_get_channel_gain(uint8_t channel)
+{
+	return config.channel[channel].gain;
+}
+
+/* Exported interface, documented in main-menu.h */
+uint8_t main_menu_conifg_get_channel_shift(uint8_t channel)
+{
+	return config.channel[channel].shift;
+}
+
+/* Exported interface, documented in main-menu.h */
+uint32_t main_menu_conifg_get_channel_offset(uint8_t channel)
+{
+	return config.channel[channel].offset;
+}
+
+/* Exported interface, documented in main-menu.h */
+bool main_menu_conifg_get_channel_sample32(uint8_t channel)
+{
+	return config.channel[channel].sample32;
+}
+
+/* Exported interface, documented in main-menu.h */
+bool main_menu_conifg_get_filter_normalise_enabled(void)
+{
+	return config.filter.normalise_enable;
+}
+
+/* Exported interface, documented in main-menu.h */
+bool main_menu_conifg_get_filter_ac_denoise_enabled(void)
+{
+	return config.filter.ac_denoise_enable;
+}
+
+/* Exported interface, documented in main-menu.h */
+double main_menu_conifg_get_filter_normalise_frequency(void)
+{
+	return config.filter.normalise;
+}
+
+/* Exported interface, documented in main-menu.h */
+double main_menu_conifg_get_filter_ac_denoise_frequency(void)
+{
+	return config.filter.ac_denoise;
+}
+
+static const char *stringify_unsigned(unsigned value)
+{
+	static char buffer[32];
+	int ret;
+
+	ret = snprintf(buffer, sizeof(buffer), "%u", value);
+	if (ret <= 0) {
+		return NULL;
+
+	} else if ((unsigned) ret >= sizeof(buffer)) {
+		return NULL;
+	}
+
+	return buffer;
+}
+
+/* Exported interface, documented in main-menu.h */
+bool main_menu_conifg_set_channel_shift(uint8_t channel, uint8_t shift)
+{
+	const char *shift_string = stringify_unsigned(shift);
+
+	if (shift_string == NULL) {
+		return false;
+	}
+
+	return sdl_tk_widget_input_set_value(
+			config.channel[channel].widget_shift,
+			shift_string);
+}
+
+/* Exported interface, documented in main-menu.h */
+bool main_menu_conifg_set_channel_offset(uint8_t channel, uint32_t offset)
+{
+	const char *offset_string = stringify_unsigned(offset);
+
+	if (offset_string == NULL) {
+		return false;
+	}
+
+	return sdl_tk_widget_input_set_value(
+			config.channel[channel].widget_offset,
+			offset_string);
+}
+
+/* Exported interface, documented in main-menu.h */
+void main_menu_set_acq_available(bool available)
+{
+	sdl_tk_widget_enable(config.widget_cal, available);
+	sdl_tk_widget_enable(config.widget_acq, available);
+}

--- a/bloodview/src/main-menu.h
+++ b/bloodview/src/main-menu.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MAIN_MENU_H
+#define MAIN_MENU_H
+
+/**
+ * Create the bloodlight main menu widget set.
+ *
+ * \return the main menu root widget or NULL on error.
+ */
+struct sdl_tk_widget *main_menu_create(void);
+
+/**
+ * Get the LED mask.
+ *
+ * \return the led mask to use.
+ */
+uint16_t main_menu_conifg_get_led_mask(void);
+
+/**
+ * Get the source mask.
+ *
+ * \return the configured led mask.
+ */
+uint16_t main_menu_conifg_get_source_mask(void);
+
+/**
+ * Get the frequency.
+ *
+ * \return the configured frequency.
+ */
+uint16_t main_menu_conifg_get_frequency(void);
+
+/**
+ * Get the oversample.
+ *
+ * \return the configured oversample.
+ */
+uint32_t main_menu_conifg_get_oversample(void);
+
+/**
+ * Get the gain for a given channel.
+ *
+ * \param[in]  channel  The channel read config from.
+ * \return the configured channel gain.
+ */
+uint8_t main_menu_conifg_get_channel_gain(uint8_t channel);
+
+/**
+ * Get the shift for a given channel.
+ *
+ * \param[in]  channel  The channel read config from.
+ * \return the configured channel shift.
+ */
+uint8_t main_menu_conifg_get_channel_shift(uint8_t channel);
+
+/**
+ * Get the offset for a given channel.
+ *
+ * \param[in]  channel  The channel read config from.
+ * \return the configured channel offset.
+ */
+uint32_t main_menu_conifg_get_channel_offset(uint8_t channel);
+
+/**
+ * Get the sample value size for a given channel.
+ *
+ * \param[in]  channel  The channel read config from.
+ * \return the configured channel sample value size.
+ */
+bool main_menu_conifg_get_channel_sample32(uint8_t channel);
+
+/**
+ * Get whether the normalisation filter is enabled.
+ *
+ * \return true if enabled, false otherwise.
+ */
+bool main_menu_conifg_get_filter_normalise_enabled(void);
+
+/**
+ * Get whether the AC noise suppression filter is enabled.
+ *
+ * \return true if enabled, false otherwise.
+ */
+bool main_menu_conifg_get_filter_ac_denoise_enabled(void);
+
+/**
+ * Get the frequency for sample normalisation.
+ *
+ * \return frequency in Hz.
+ */
+double main_menu_conifg_get_filter_normalise_frequency(void);
+
+/**
+ * Get the frequency for AC noise suppression.
+ *
+ * \return frequency in Hz.
+ */
+double main_menu_conifg_get_filter_ac_denoise_frequency(void);
+
+/**
+ * Set the shift configuration value for a given channel.
+ *
+ * \param[in]  channel  The channel update config for.
+ * \param[in]  shift    The config value to set.
+ * \return true if the config value was successfully updated, false otherwise.
+ */
+bool main_menu_conifg_set_channel_shift(uint8_t channel, uint8_t shift);
+
+/**
+ * Set the offset configuration value for a given channel.
+ *
+ * \param[in]  channel  The channel update config for.
+ * \param[in]  offset   The config value to set.
+ * \return true if the config value was successfully updated, false otherwise.
+ */
+bool main_menu_conifg_set_channel_offset(uint8_t channel, uint32_t offset);
+
+/**
+ * Set whether acquisition is currently possible.
+ *
+ * \param[in]  available  Whether it is possible to start an acqusition.
+ */
+void main_menu_set_acq_available(bool available);
+
+#endif /* MAIN_MENU_H */

--- a/bloodview/src/sdl.c
+++ b/bloodview/src/sdl.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+
+#include <SDL2/SDL.h>
+
+#include "sdl-tk/widget.h"
+
+#include "main-menu.h"
+
+/** Mask of SDL subsystems we use. */
+#define BL_SDL_INIT_MASK (SDL_INIT_VIDEO)
+
+/**
+ * SDL module context global.
+ */
+static struct sdl_ctx
+{
+	SDL_Window   *win;
+	SDL_Renderer *ren;
+
+	struct sdl_tk_widget *main_menu;
+	bool                  main_menu_open;
+
+	unsigned w;
+	unsigned h;
+} ctx;
+
+/* Exported interface, documented in sdl.h */
+void sdl_fini(void)
+{
+	sdl_tk_widget_destroy(ctx.main_menu);
+	sdl_tk_text_fini();
+	sdl_tk_colour_fini();
+
+	if (ctx.ren != NULL) {
+		SDL_DestroyRenderer(ctx.ren);
+		ctx.ren = NULL;
+	}
+	if (ctx.win != NULL) {
+		SDL_DestroyWindow(ctx.win);
+		ctx.ren = NULL;
+	}
+	if (SDL_WasInit(BL_SDL_INIT_MASK) == BL_SDL_INIT_MASK) {
+		SDL_Quit();
+	}
+}
+
+/* Exported interface, documented in sdl.h */
+bool sdl_init(const char *font_path)
+{
+	if (SDL_Init(BL_SDL_INIT_MASK) != 0) {
+		fprintf(stderr, "SDL_Init Error: %s\n",
+				SDL_GetError());
+		goto error;
+	}
+
+	ctx.w = 1280;
+	ctx.h = 720;
+
+	ctx.win = SDL_CreateWindow("Bloodlight",
+			SDL_WINDOWPOS_CENTERED,
+			SDL_WINDOWPOS_CENTERED,
+			ctx.w, ctx.h,
+			SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
+	if (ctx.win == NULL) {
+		fprintf(stderr, "SDL_CreateWindow Error: %s\n",
+				SDL_GetError());
+		goto error;
+	}
+
+	ctx.ren = SDL_CreateRenderer(ctx.win, -1,
+			SDL_RENDERER_ACCELERATED |
+			SDL_RENDERER_PRESENTVSYNC);
+	if (ctx.ren == NULL) {
+		fprintf(stderr, "SDL_CreateRenderer Error: %s\n",
+				SDL_GetError());
+		goto error;
+	}
+
+	if (!sdl_tk_colour_init()) {
+		goto error;
+	}
+
+	if (!sdl_tk_text_init(ctx.ren, font_path)) {
+		goto error;
+	}
+
+	ctx.main_menu = main_menu_create();
+	if (ctx.main_menu == NULL) {
+		goto error;
+	}
+
+	return true;
+
+error:
+	sdl_fini();
+	return false;
+}
+
+/**
+ * Handle keyboard and mouse input.
+ *
+ * \param[in]  event  SDL event to handle.
+ */
+static void sdl__handle_input(SDL_Event *event)
+{
+	if (!sdl_tk_widget_input(ctx.main_menu, event)) {
+		switch (event->type) {
+		case SDL_KEYDOWN:
+			switch (event->key.keysym.sym) {
+			case SDLK_ESCAPE:
+				ctx.main_menu_open = !ctx.main_menu_open;
+				sdl_tk_widget_focus(
+						ctx.main_menu,
+						ctx.main_menu_open);
+				break;
+
+			default:
+				break;
+			}
+			break;
+		}
+	}
+}
+
+/* Exported interface, documented in sdl.h */
+void sdl_main_menu_close(void)
+{
+	ctx.main_menu_open = false;
+	sdl_tk_widget_focus(
+			ctx.main_menu,
+			ctx.main_menu_open);
+}
+
+/* Exported interface, documented in sdl.h */
+bool sdl_handle_input(void)
+{
+	static SDL_Event event;
+
+	while (SDL_PollEvent(&event)) {
+		switch (event.type) {
+		case SDL_QUIT:
+			return false;
+
+		case SDL_KEYDOWN:
+		case SDL_MOUSEMOTION:
+		case SDL_MOUSEBUTTONDOWN:
+		case SDL_MOUSEBUTTONUP:
+			sdl__handle_input(&event);
+			break;
+		}
+	}
+
+	return true;
+}
+
+/* Exported interface, documented in sdl.h */
+void sdl_present(void)
+{
+	SDL_Color bg = sdl_tk_colour_get(SDL_TK_COLOUR_BACKGROUND);
+
+	SDL_SetRenderDrawColor(ctx.ren, bg.r, bg.g, bg.b, 255);
+	SDL_RenderClear(ctx.ren);
+
+	sdl_tk_widget_render(ctx.main_menu, ctx.ren, ctx.w / 2, ctx.h / 2);
+	SDL_RenderPresent(ctx.ren);
+}

--- a/bloodview/src/sdl.c
+++ b/bloodview/src/sdl.c
@@ -20,6 +20,7 @@
 
 #include "sdl-tk/widget.h"
 
+#include "graph.h"
 #include "main-menu.h"
 
 /** Mask of SDL subsystems we use. */
@@ -131,6 +132,7 @@ static void sdl__handle_input(SDL_Event *event)
 				break;
 
 			default:
+				graph_handle_input(event);
 				break;
 			}
 			break;
@@ -172,10 +174,18 @@ bool sdl_handle_input(void)
 /* Exported interface, documented in sdl.h */
 void sdl_present(void)
 {
+	const SDL_Rect r = {
+		.x = 0,
+		.y = 0,
+		.w = ctx.w,
+		.h = ctx.h,
+	};
 	SDL_Color bg = sdl_tk_colour_get(SDL_TK_COLOUR_BACKGROUND);
 
 	SDL_SetRenderDrawColor(ctx.ren, bg.r, bg.g, bg.b, 255);
 	SDL_RenderClear(ctx.ren);
+
+	graph_render(ctx.ren, &r);
 
 	sdl_tk_widget_render(ctx.main_menu, ctx.ren, ctx.w / 2, ctx.h / 2);
 	SDL_RenderPresent(ctx.ren);

--- a/bloodview/src/sdl.c
+++ b/bloodview/src/sdl.c
@@ -106,6 +106,11 @@ bool sdl_init(const char *font_path)
 		goto error;
 	}
 
+	ctx.main_menu_open = true;
+	sdl_tk_widget_focus(
+			ctx.main_menu,
+			ctx.main_menu_open);
+
 	return true;
 
 error:

--- a/bloodview/src/sdl.h
+++ b/bloodview/src/sdl.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BV_SDL_H
+#define BV_SDL_H
+
+#include <stdbool.h>
+
+/**
+ * Finalise the SDL module.
+ */
+void sdl_fini(void);
+
+/**
+ * Initialise the SDL module.
+ *
+ * \param[in]  font_path  Path to font to use for the interface, or NULL.
+ * \return true on success or false on failure.
+ */
+bool sdl_init(const char *font_path);
+
+/**
+ * Handle any SDL events.
+ *
+ * \return false if the program should quit, otherwise true.
+ */
+bool sdl_handle_input(void);
+
+/**
+ * Close the main menu.
+ */
+void sdl_main_menu_close(void);
+
+/**
+ * Render the display.
+ */
+void sdl_present(void);
+
+#endif /* BV_SDL_H */

--- a/bloodview/src/util.h
+++ b/bloodview/src/util.h
@@ -17,6 +17,11 @@
 #ifndef BV_UTIL_H
 #define BV_UTIL_H
 
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
 /**
  * Helper to squash warnings about unused variables.
  *
@@ -33,5 +38,59 @@
  */
 #define BV_ARRAY_LEN(_a) \
 	((sizeof(_a)) / (sizeof(*_a)))
+
+/**
+ * Parse an unsigned value from a string.
+ *
+ * \param[in]  string  String to be parsed.
+ * \param[in]  out     Returns the value parsed out of string on success.
+ * \return true on success, false on error.
+ */
+static inline bool util_read_unsigned(
+		const char *string,
+		unsigned *out)
+{
+	unsigned long long temp;
+	char *end = NULL;
+
+	errno = 0;
+	temp = strtoull(string, &end, 0);
+
+	if (end == string || errno == ERANGE) {
+		return false;
+	}
+
+	if (temp > (unsigned long long)UINT_MAX) {
+		return false;
+	}
+
+	*out = (unsigned)temp;
+	return true;
+}
+
+/**
+ * Parse an double value from a string.
+ *
+ * \param[in]  string  String to be parsed.
+ * \param[in]  out     Returns the value parsed out of string on success.
+ * \return true on success, false on error.
+ */
+static inline bool util_read_double(
+		const char *string,
+		double *out)
+{
+	double temp;
+	char *end = NULL;
+
+	errno = 0;
+	temp = strtod(string, &end);
+
+	if (end == string || errno == ERANGE) {
+		return false;
+	}
+
+	*out = temp;
+	return true;
+}
 
 #endif

--- a/bloodview/src/util.h
+++ b/bloodview/src/util.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BV_UTIL_H
+#define BV_UTIL_H
+
+/**
+ * Helper to squash warnings about unused variables.
+ *
+ * \param[in]  _u  The variable that is unused.
+ */
+#define BV_UNUSED(_u) \
+	((void)(_u))
+
+/**
+ * Helper to get the number of entires in an array.
+ *
+ * \param[in]  _a  Array to get the entry count for.
+ * \return entry count of array.
+ */
+#define BV_ARRAY_LEN(_a) \
+	((sizeof(_a)) / (sizeof(*_a)))
+
+#endif

--- a/tools/device.c
+++ b/tools/device.c
@@ -261,7 +261,6 @@ int bl_device_open(const char *dev_path)
 		bl_device_list_free(devices, count);
 		return -1;
 	}
-	bl_device_list_free(devices, count);
 
 	if (tcgetattr(dev_fd, &t) == 0) {
 		t.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
@@ -272,13 +271,17 @@ int bl_device_open(const char *dev_path)
 		if (tcsetattr(dev_fd, TCSANOW, &t) != 0) {
 			fprintf(stderr, "Failed set terminal attributes"
 				" of '%s': %s\n", dev_path, strerror(errno));
+			bl_device_list_free(devices, count);
 			return -1;
 		}
 	} else {
 		fprintf(stderr, "Failed get terminal attributes"
 				" of '%s': %s\n", dev_path, strerror(errno));
+		bl_device_list_free(devices, count);
 		return -1;
 	}
+
+	bl_device_list_free(devices, count);
 	return dev_fd;
 }
 


### PR DESCRIPTION
This is the initial version of the Bloodview host application.

It currently supports:

* Controlling a Bloodlight device.
* Starting / stopping calibrations and acquisitions.
* Filtering out the long-term changes, so that the pulse is obvious.
* Filtering out 50 Hz (configurable) AC noise.
* Graph rendering.
* Keyboard input / control.
* Acquisition recordings to file.

Note that only 32-bit acquisitions are useful at the moment, because the code to perform the channel calibration after a calibration acquisition has not yet been written.