### PR TITLE
Add support for configured and ad-hoc graph inversion

### DIFF
--- a/bloodview/Makefile
+++ b/bloodview/Makefile
@@ -22,6 +22,7 @@ endif
 MKDIR =	mkdir -p
 
 BV_SRC = \
+	src/data-invert.c \
 	src/bloodview.c \
 	src/main-menu.c \
 	src/data-avg.c \

--- a/bloodview/README.md
+++ b/bloodview/README.md
@@ -33,6 +33,7 @@ of the acquisition.
 
 | Key                     | Meaning                             |
 | ----------------------- | ----------------------------------- |
+| <kbd>i</kbd>            | Toggle graph inversion.             |
 | <kbd>Return</kbd>       | Toggle single graph mode.           |
 | <kbd>Cursor Up</kbd>    | Increase scale in the Y direction.  |
 | <kbd>Cursor Down</kbd>  | Decrease scale in the Y direction.  |

--- a/bloodview/src/data-avg.c
+++ b/bloodview/src/data-avg.c
@@ -72,6 +72,7 @@ error:
 	for (unsigned i = 0; i < count; i++) {
 		free(channel[i].data);
 	}
+	free(channel);
 
 	return NULL;
 }

--- a/bloodview/src/data-invert.c
+++ b/bloodview/src/data-invert.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include "data-invert.h"
+#include "util.h"
+
+/** Averaging filter context. */
+struct data_invert_ctx {
+	unsigned invert;
+	unsigned count;
+};
+
+/* Exported interface, documented in data-invert.h */
+void data_invert_fini(void *pw)
+{
+	struct data_invert_ctx *ctx = pw;
+
+	free(ctx);
+}
+
+/* Exported interface, documented in data-invert.h */
+void *data_invert_init(
+		const struct data_invert_config *config,
+		unsigned frequency,
+		unsigned channels,
+		uint32_t src_mask)
+{
+	struct data_invert_ctx *ctx;
+	unsigned index;
+
+	BV_UNUSED(frequency);
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (ctx == NULL) {
+		return NULL;
+	}
+
+	index = 0;
+	for (unsigned i = 0; i < BL_ACQ__SRC_COUNT; i++) {
+		if (src_mask & (1u << i)) {
+			if (config->invert[index] == true) {
+				ctx->invert |= (1u << index);
+			}
+			index++;
+		}
+	}
+
+	ctx->count = channels;
+	return ctx;
+}
+
+/* Exported interface, documented in data-invert.h */
+uint32_t data_invert_proc(
+		void *pw,
+		unsigned channel,
+		uint32_t sample)
+{
+	struct data_invert_ctx *ctx = pw;
+
+	assert(channel < ctx->count);
+
+	if (ctx->invert & (1u << channel)) {
+		sample = UINT32_MAX - sample;
+	}
+
+	return sample;
+}

--- a/bloodview/src/data-invert.h
+++ b/bloodview/src/data-invert.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BV_DATA_INVERT_H
+#define BV_DATA_INVERT_H
+
+#include "../../src/acq.h"
+
+/**
+ * The data inverting filter's configuration.
+ */
+struct data_invert_config {
+	bool invert[BL_ACQ__SRC_COUNT];
+};
+
+/**
+ * Finalise a given data inverting filter session.
+ *
+ * \param[in]  pw  Data inverting filter session context.
+ */
+void data_invert_fini(void *pw);
+
+/**
+ * Create a data inverting filter session.
+ *
+ * \param[in]  config     Filter-specific configuration.
+ * \param[in]  frequency  The sampling frequency.
+ * \param[in]  channels   The number of channels.
+ * \param[in]  src_mask   Mask of enabled sources.
+ * \return a context pointer on success, or NULL on error.
+ */
+void *data_invert_init(
+		const struct data_invert_config *config,
+		unsigned frequency,
+		unsigned channels,
+		uint32_t src_mask);
+
+/**
+ * Handle a sample for a given channel.
+ *
+ * \param[in]  pw       The data inverting filter context.
+ * \param[in]  channel  The channel index.
+ * \param[in]  sample   The sample value to filter.
+ * \return true on success, false on error.
+ */
+uint32_t data_invert_proc(
+		void *pw,
+		unsigned channel,
+		uint32_t sample);
+
+#endif /* BV_DATA_INVERT_H */

--- a/bloodview/src/data.c
+++ b/bloodview/src/data.c
@@ -269,29 +269,10 @@ static bool data__register_filters(
 	return true;
 }
 
-/**
- * Count the bits sent in a mask
- *
- * \param[in]  mask  The mask to count the bits set in.
- * \return the number of bits set in mask.
- */
-static unsigned bit_count(unsigned mask)
-{
-	unsigned count = 0;
-
-	for (unsigned i = 0; i < sizeof(mask) * CHAR_BIT; i++) {
-		if (mask & (1u << i)) {
-			count++;
-		}
-	}
-
-	return count;
-}
-
 /* Exported interface, documented in data.h */
 bool data_start(bool calibrate, unsigned frequency, unsigned src_mask)
 {
-	unsigned channels = bit_count(src_mask);
+	unsigned channels = util_bit_count(src_mask);
 	unsigned n = 0;
 
 	assert(data_g.enabled == false);

--- a/bloodview/src/data.c
+++ b/bloodview/src/data.c
@@ -25,6 +25,7 @@
 #include "graph.h"
 #include "data-avg.h"
 #include "main-menu.h"
+#include "data-invert.h"
 
 struct data_filter {
 	void *ctx;
@@ -200,6 +201,54 @@ static bool data__register_normalise(
 }
 
 /**
+ * Resister the inverting filter.
+ *
+ * \param[in]  frequency  The sampling frequency.
+ * \param[in]  channels   The number of channels.
+ * \param[in]  src_mask   Mask of enabled sources.
+ * \return true on success, or false on error.
+ */
+static bool data__register_invert(
+		unsigned frequency,
+		unsigned channels,
+		uint32_t src_mask)
+{
+	bool enabled = false;
+	struct data_filter *filter;
+	struct data_invert_config config = { 0 };
+
+	for (unsigned i = 0; i < BL_ACQ__SRC_COUNT; i++) {
+		config.invert[i] = main_menu_conifg_get_channel_inverted(i);
+		if (config.invert[i]) {
+			enabled = true;
+		}
+	}
+
+	if (!enabled) {
+		/* No inversion required. */
+		return true;
+	}
+
+	filter = data__allocate_filter();
+	if (filter == NULL) {
+		return false;
+	}
+
+	filter->ctx = data_invert_init(&config, frequency, channels, src_mask);
+	if (filter->ctx == NULL) {
+		/* No need to free the filter, it's already owned by the
+		 * global state. */
+		return false;
+	}
+
+	filter->fini = data_invert_fini;
+	filter->proc = data_invert_proc;
+
+	data_g.count++;
+	return true;
+}
+
+/**
  * Resister the normalising filter, if enabled.
  *
  * \param[in]  frequency  The sampling frequency.
@@ -253,6 +302,10 @@ static bool data__register_filters(
 		uint32_t src_mask)
 {
 	BV_UNUSED(calibrate);
+
+	if (!data__register_invert(frequency, channels, src_mask)) {
+		return false;
+	}
 
 	if (main_menu_conifg_get_filter_normalise_enabled() &&
 			!data__register_normalise(

--- a/bloodview/src/data.c
+++ b/bloodview/src/data.c
@@ -180,8 +180,6 @@ static bool data__register_normalise(
 		.normalise   = true,
 	};
 
-	BV_UNUSED(src_mask);
-
 	filter = data__allocate_filter();
 	if (filter == NULL) {
 		return false;
@@ -219,8 +217,6 @@ static bool data__register_ac_denoise(
 		.filter_freq = (frequency / main_menu_conifg_get_filter_ac_denoise_frequency()) * 1024,
 		.normalise   = false,
 	};
-
-	BV_UNUSED(src_mask);
 
 	filter = data__allocate_filter();
 	if (filter == NULL) {

--- a/bloodview/src/graph.c
+++ b/bloodview/src/graph.c
@@ -290,7 +290,12 @@ cleanup:
 	pthread_mutex_unlock(&graph_g.lock);
 }
 
-/* Exported function, documented in graph.h */
+/**
+ * Increment a graphs's y-scale.
+ *
+ * \param[in]  idx  Index of graph to scale.
+ * \return true if scale changed, false otherwise.
+ */
 static bool graph__y_scale_inc(unsigned idx)
 {
 	struct graph *g = graph_g.channel + idx;
@@ -309,7 +314,12 @@ static bool graph__y_scale_inc(unsigned idx)
 	return (g->scale != old);
 }
 
-/* Exported function, documented in graph.h */
+/**
+ * Decrement a graphs's y-scale.
+ *
+ * \param[in]  idx  Index of graph to scale.
+ * \return true if scale changed, false otherwise.
+ */
 static bool graph__y_scale_dec(unsigned idx)
 {
 	struct graph *g = graph_g.channel + idx;

--- a/bloodview/src/main-menu.c
+++ b/bloodview/src/main-menu.c
@@ -75,6 +75,7 @@ struct main_menu_config_channel {
 	unsigned offset;
 	unsigned shift;
 	bool     sample32;
+	bool     inverted;
 
 	struct sdl_tk_widget *widget_shift;
 	struct sdl_tk_widget *widget_offset;
@@ -311,6 +312,7 @@ enum {
 	CHAN_OFFSET,
 	CHAN_SHIFT,
 	CHAN_32BIT,
+	CHAN_INVERT,
 };
 
 /**
@@ -344,6 +346,10 @@ static const struct main_menu_widget_desc bl_menu_config_chan_c_entries[] = {
 	[CHAN_32BIT] = {
 		.type   = WIDGET_TYPE_TOGGLE,
 		.title  = "32-bit samples",
+	},
+	[CHAN_INVERT] = {
+		.type   = WIDGET_TYPE_TOGGLE,
+		.title  = "Invert data",
 	},
 };
 
@@ -624,6 +630,7 @@ static void *get_config_pw_for_entry(
 		case CHAN_OFFSET: return &config.channel[chan_entry].offset;
 		case CHAN_SHIFT:  return &config.channel[chan_entry].shift;
 		case CHAN_32BIT:  return &config.channel[chan_entry].sample32;
+		case CHAN_INVERT: return &config.channel[chan_entry].inverted;
 		}
 
 	} else if (entries == bl_menu_config_led_entries) {
@@ -847,6 +854,12 @@ uint32_t main_menu_conifg_get_channel_offset(uint8_t channel)
 bool main_menu_conifg_get_channel_sample32(uint8_t channel)
 {
 	return config.channel[channel].sample32;
+}
+
+/* Exported interface, documented in main-menu.h */
+bool main_menu_conifg_get_channel_inverted(uint8_t channel)
+{
+	return config.channel[channel].inverted;
 }
 
 /* Exported interface, documented in main-menu.h */

--- a/bloodview/src/main-menu.h
+++ b/bloodview/src/main-menu.h
@@ -85,6 +85,14 @@ uint32_t main_menu_conifg_get_channel_offset(uint8_t channel);
 bool main_menu_conifg_get_channel_sample32(uint8_t channel);
 
 /**
+ * Get whether the channel is inverted.
+ *
+ * \param[in]  channel  The channel to read config from.
+ * \return the configured channel sample value size.
+ */
+bool main_menu_conifg_get_channel_inverted(uint8_t channel);
+
+/**
  * Get whether the normalisation filter is enabled.
  *
  * \return true if enabled, false otherwise.

--- a/bloodview/src/main-menu.h
+++ b/bloodview/src/main-menu.h
@@ -55,7 +55,7 @@ uint32_t main_menu_conifg_get_oversample(void);
 /**
  * Get the gain for a given channel.
  *
- * \param[in]  channel  The channel read config from.
+ * \param[in]  channel  The channel to read config from.
  * \return the configured channel gain.
  */
 uint8_t main_menu_conifg_get_channel_gain(uint8_t channel);
@@ -63,7 +63,7 @@ uint8_t main_menu_conifg_get_channel_gain(uint8_t channel);
 /**
  * Get the shift for a given channel.
  *
- * \param[in]  channel  The channel read config from.
+ * \param[in]  channel  The channel to read config from.
  * \return the configured channel shift.
  */
 uint8_t main_menu_conifg_get_channel_shift(uint8_t channel);
@@ -71,7 +71,7 @@ uint8_t main_menu_conifg_get_channel_shift(uint8_t channel);
 /**
  * Get the offset for a given channel.
  *
- * \param[in]  channel  The channel read config from.
+ * \param[in]  channel  The channel to read config from.
  * \return the configured channel offset.
  */
 uint32_t main_menu_conifg_get_channel_offset(uint8_t channel);
@@ -79,7 +79,7 @@ uint32_t main_menu_conifg_get_channel_offset(uint8_t channel);
 /**
  * Get the sample value size for a given channel.
  *
- * \param[in]  channel  The channel read config from.
+ * \param[in]  channel  The channel to read config from.
  * \return the configured channel sample value size.
  */
 bool main_menu_conifg_get_channel_sample32(uint8_t channel);

--- a/bloodview/src/util.h
+++ b/bloodview/src/util.h
@@ -93,4 +93,23 @@ static inline bool util_read_double(
 	return true;
 }
 
+/**
+ * Count the bits sent in a mask
+ *
+ * \param[in]  mask  The mask to count the bits set in.
+ * \return the number of bits set in mask.
+ */
+static inline unsigned util_bit_count(unsigned mask)
+{
+	unsigned count = 0;
+
+	for (unsigned i = 0; i < sizeof(mask) * CHAR_BIT; i++) {
+		if (mask & (1u << i)) {
+			count++;
+		}
+	}
+
+	return count;
+}
+
 #endif


### PR DESCRIPTION
Sources can be configured as inverted in the main-menu, on a per-channel basis.  This inversion is applied as a data filter.

Graph rendering can also be inverted on the fly, by pressing the <kbd>i</kbd> key to toggle inversion of the selected graph.