### PR TITLE
Bloodview: Calibration support for revision 1

### DIFF
--- a/bloodview/Makefile
+++ b/bloodview/Makefile
@@ -26,6 +26,7 @@ BV_SRC = \
 	src/bloodview.c \
 	src/main-menu.c \
 	src/data-avg.c \
+	src/data-cal.c \
 	src/device.c \
 	src/graph.c \
 	src/data.c \

--- a/bloodview/src/data-avg.c
+++ b/bloodview/src/data-avg.c
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <assert.h>
 #include <stdint.h>

--- a/bloodview/src/data-cal.c
+++ b/bloodview/src/data-cal.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include "../../src/acq.h"
+
+#include "util.h"
+#include "data-cal.h"
+#include "main-menu.h"
+
+/** Channel tracking. */
+struct channel_data {
+	uint32_t sample_min;
+	uint32_t sample_max;
+};
+
+/** Calibration context. */
+struct data_cal_ctx {
+	struct channel_data *channel;
+	unsigned count;
+
+	uint32_t src_mask;
+};
+
+/**
+ * Get the shift and offset for a given channel.
+ *
+ * \param[in]  bits        The number of bits to calibrate the value for.
+ * \param[in]  sample_min  Minumum sample value recorded.
+ * \param[in]  sample_max  Maximum sample value recorded.
+ * \param[out] out_shift   Returns the value shift to set for the channel.
+ * \param[out] out_offset  Returns the value offset to set for the channel.
+ */
+static void data_cal__calibrate_channel(
+		uint8_t   bits,
+		uint32_t  sample_min,
+		uint32_t  sample_max,
+		uint32_t *out_shift,
+		uint32_t *out_offset)
+{
+	uint32_t max_range    = (1U << bits) - 1;
+	uint32_t margin       = max_range / 4;
+	uint32_t target_range = max_range - (margin * 2);
+	uint32_t range        = sample_max - sample_min;
+	uint32_t shift        = 0;
+	uint32_t offset;
+
+	while ((range >> shift) > target_range) {
+		shift++;
+	}
+
+	offset = (margin < sample_min) ? (sample_min - margin) : 0;
+
+	*out_shift  = shift;
+	*out_offset = offset;
+}
+
+/**
+ * Convert a data channel to an acquisition source.
+ *
+ * \param[in]  ctx      The calibration context.
+ * \param[in]  channel  The channel to find the source for.
+ * \return the channel's acquisition source.
+ */
+static enum bl_acq_source data_cal__channel_to_source(
+		const struct data_cal_ctx *ctx,
+		unsigned channel)
+{
+	for (unsigned i = 0; i < 32; i++) {
+		if (ctx->src_mask & (1u << i)) {
+			if (channel == 0) {
+				return i;
+			}
+			channel--;
+		}
+	}
+
+	return BL_ACQ__SRC_COUNT;
+}
+
+/* Exported interface, documented in data-cal.h */
+void data_cal_fini(void *pw)
+{
+	struct data_cal_ctx *ctx = pw;
+
+	for (unsigned i = 0; i < ctx->count; i++) {
+		struct channel_data *c = &ctx->channel[i];
+		enum bl_acq_source src;
+		uint32_t offset;
+		uint32_t shift;
+
+		data_cal__calibrate_channel(16,
+				c->sample_min,
+				c->sample_max,
+				&shift, &offset);
+
+		src = data_cal__channel_to_source(ctx, i);
+		if (src >= BL_ACQ__SRC_COUNT) {
+			continue;
+		}
+
+		main_menu_conifg_set_channel_shift(i, shift);
+		main_menu_conifg_set_channel_offset(i, offset);
+	}
+
+	free(ctx->channel);
+	free(ctx);
+}
+
+/**
+ * Allocate the channel array.
+ *
+ * \param[in]  count     The number of channels.
+ */
+static struct channel_data *data_cal__init_channel_array(
+		unsigned count)
+{
+	struct channel_data *channel;
+
+	channel = calloc(sizeof(*channel), count);
+	if (channel == NULL) {
+		return NULL;
+	}
+
+	for (unsigned i = 0; i < count; i++) {
+		channel[i].sample_min = 0xFFFFFFFFu;
+		channel[i].sample_max = 0x00000000u;
+	}
+
+	return channel;
+}
+
+/* Exported interface, documented in data-cal.h */
+void *data_cal_init(
+		unsigned frequency,
+		unsigned channels,
+		uint32_t src_mask)
+{
+	struct data_cal_ctx *ctx;
+
+	BV_UNUSED(frequency);
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (ctx == NULL) {
+		return NULL;
+	}
+
+	ctx->channel = data_cal__init_channel_array(channels);
+	if (ctx->channel == NULL) {
+		free(ctx);
+		return NULL;
+	}
+
+	ctx->src_mask = src_mask;
+	ctx->count = channels;
+	return ctx;
+}
+
+/* Exported interface, documented in data-cal.h */
+uint32_t data_cal_proc(
+		void *pw,
+		unsigned channel,
+		uint32_t sample)
+{
+	struct data_cal_ctx *ctx = pw;
+	struct channel_data *c;
+
+	assert(channel < ctx->count);
+
+	c = &ctx->channel[channel];
+
+	if (sample < c->sample_min) {
+		c->sample_min = sample;
+	}
+	if (sample > c->sample_max) {
+		c->sample_max = sample;
+	}
+
+	return sample;
+}

--- a/bloodview/src/data-cal.h
+++ b/bloodview/src/data-cal.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BV_DATA_CAL_H
+#define BV_DATA_CAL_H
+
+/**
+ * Finalise a given data calibration filter session.
+ *
+ * \param[in]  pw  Data calibration filter session context.
+ */
+void data_cal_fini(void *pw);
+
+/**
+ * Create a data calibration filter session.
+ *
+ * \param[in]  frequency  The sampling frequency.
+ * \param[in]  channels   The number of channels.
+ * \param[in]  src_mask   Mask of enabled sources.
+ * \return a context pointer on success, or NULL on error.
+ */
+void *data_cal_init(
+		unsigned frequency,
+		unsigned channels,
+		uint32_t src_mask);
+
+/**
+ * Handle a sample for a given channel.
+ *
+ * \param[in]  pw       The data calibration filter context.
+ * \param[in]  channel  The channel index.
+ * \param[in]  sample   The sample value to filter.
+ * \return true on success, false on error.
+ */
+uint32_t data_cal_proc(
+		void *pw,
+		unsigned channel,
+		uint32_t sample);
+
+#endif /* BV_DATA_CAL_H */

--- a/bloodview/src/device.c
+++ b/bloodview/src/device.c
@@ -21,8 +21,6 @@
 #include <string.h>
 #include <stdbool.h>
 
-#include <pthread.h>
-
 #include "../../src/msg.h"
 #include "../../tools/msg.h"
 #include "../../tools/device.h"
@@ -30,6 +28,7 @@
 #include "data.h"
 #include "util.h"
 #include "device.h"
+#include "locked.h"
 #include "main-menu.h"
 
 /** Special code for indicating the start of an acquisition. */
@@ -37,80 +36,6 @@
 
 /** Special code for indicating the start of a calibration. */
 #define MSG_START_SPECIAL_ACQ ((enum bl_msg_type) 254)
-
-/** A locked unsigned integer. */
-typedef struct locked_uint {
-	pthread_mutex_t lock;
-	unsigned        value;
-} locked_uint_t;
-
-/**
- * Check whether a locked value is equal to a given value.
- *
- * \param[in]  lu     Locked unsigned value to check.
- * \param[in]  value  The value to compare against.
- * \return true if the locked unsigned value is equal to the given value.
- */
-static inline bool locked_uint_is_equal(
-		locked_uint_t *lu,
-		unsigned value)
-{
-	bool ret;
-
-	pthread_mutex_lock(&lu->lock);
-	ret = (lu->value == value);
-	pthread_mutex_unlock(&lu->lock);
-
-	return ret;
-}
-
-/**
- * Increment a locked unsigned value.
- *
- * \param[in]  lu  Locked unsigned value to change.
- */
-static inline void locked_uint_inc(
-		locked_uint_t *lu)
-{
-	pthread_mutex_lock(&lu->lock);
-	lu->value++;
-	pthread_mutex_unlock(&lu->lock);
-}
-
-/**
- * Decrement a locked unsigned value.
- *
- * \param[in]  lu  Locked unsigned value to change.
- */
-static inline void locked_uint_dec(
-		locked_uint_t *lu)
-{
-	pthread_mutex_lock(&lu->lock);
-	lu->value--;
-	pthread_mutex_unlock(&lu->lock);
-}
-
-/**
- * Set a locked unsigned value.
- *
- * \param[in]  lu     Locked unsigned value to change.
- * \param[in]  value  New value.
- * \return true if the locked value changed, false otherwise.
- */
-static inline bool locked_uint_set(
-		locked_uint_t *lu,
-		unsigned value)
-{
-	bool ret = false;
-
-	pthread_mutex_lock(&lu->lock);
-	if (lu->value != value) {
-		lu->value = value;
-		ret = true;
-	}
-	pthread_mutex_unlock(&lu->lock);
-	return ret;
-}
 
 /** Maximum number of messages that can be queued for sending. */
 #define MSG_FIFO_MAX 16

--- a/bloodview/src/locked.h
+++ b/bloodview/src/locked.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2020 Codethink Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BV_LOCKED_H
+#define BV_LOCKED_H
+
+#include <pthread.h>
+
+/** A locked unsigned integer. */
+typedef struct locked_uint {
+	pthread_mutex_t   lock;
+	volatile unsigned value;
+} locked_uint_t;
+
+/**
+ * Claim a locked uint.
+ *
+ * \param[in]  lu     Locked unsigned value to change.
+ * \param[in]  value  New value.
+ * \return true if the locked value changed, false otherwise.
+ */
+static inline bool locked_uint_claim(
+		locked_uint_t *lu)
+{
+	return pthread_mutex_lock(&lu->lock) == 0;
+}
+
+/**
+ * Release a locked uint.
+ *
+ * \param[in]  lu     Locked unsigned value to change.
+ * \param[in]  value  New value.
+ * \return true if the locked value changed, false otherwise.
+ */
+static inline bool locked_uint_release(
+		locked_uint_t *lu)
+{
+	return pthread_mutex_unlock(&lu->lock) == 0;
+}
+
+/**
+ * Check whether a locked value is equal to a given value.
+ *
+ * \param[in]  lu     Locked unsigned value to check.
+ * \param[in]  value  The value to compare against.
+ * \return true if the locked unsigned value is equal to the given value.
+ */
+static inline bool locked_uint_is_equal(
+		locked_uint_t *lu,
+		unsigned value)
+{
+	bool ret;
+
+	locked_uint_claim(lu);
+	ret = (lu->value == value);
+	locked_uint_release(lu);
+
+	return ret;
+}
+
+/**
+ * Increment a locked unsigned value.
+ *
+ * \param[in]  lu  Locked unsigned value to change.
+ */
+static inline void locked_uint_inc(
+		locked_uint_t *lu)
+{
+	locked_uint_claim(lu);
+	lu->value++;
+	locked_uint_release(lu);
+}
+
+/**
+ * Decrement a locked unsigned value.
+ *
+ * \param[in]  lu  Locked unsigned value to change.
+ */
+static inline void locked_uint_dec(
+		locked_uint_t *lu)
+{
+	locked_uint_claim(lu);
+	lu->value--;
+	locked_uint_release(lu);
+}
+
+/**
+ * Set a locked unsigned value.
+ *
+ * \param[in]  lu     Locked unsigned value to change.
+ * \param[in]  value  New value.
+ * \return true if the locked value changed, false otherwise.
+ */
+static inline bool locked_uint_set(
+		locked_uint_t *lu,
+		unsigned value)
+{
+	bool ret = false;
+
+	locked_uint_claim(lu);
+	if (lu->value != value) {
+		lu->value = value;
+		ret = true;
+	}
+	locked_uint_release(lu);
+	return ret;
+}
+
+#endif /* BV_LOCKED_H */

--- a/bloodview/src/main-menu.h
+++ b/bloodview/src/main-menu.h
@@ -25,6 +25,11 @@
 struct sdl_tk_widget *main_menu_create(void);
 
 /**
+ * Update the main menu state.
+ */
+void main_menu_update(void);
+
+/**
  * Get the LED mask.
  *
  * \return the led mask to use.

--- a/bloodview/src/sdl.c
+++ b/bloodview/src/sdl.c
@@ -222,6 +222,7 @@ void sdl_present(void)
 
 	graph_render(ctx.ren, &r);
 
+	main_menu_update();
 	sdl_tk_widget_render(ctx.main_menu, ctx.ren, ctx.w / 2, ctx.h / 2);
 	SDL_RenderPresent(ctx.ren);
 }


### PR DESCRIPTION
This adds calibration support for revision 1.

There is a stub for "undoing" the 16-bit calibration.  It can be implemented later if usage proves it is actually needed.