### PR TITLE
Split concepts of sources and channels and expose rev2 source attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CFILES = \
 	src/acq/dma.c \
 	src/acq/adc.c \
 	src/acq/opamp.c \
-	src/acq/channel.c
+	src/acq/source.c
 
 REVISION ?= 1
 CFLAGS += -DBL_REVISION=$(REVISION)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ CFILES = \
 	src/acq/dma.c \
 	src/acq/adc.c \
 	src/acq/opamp.c \
-	src/acq/source.c
+	src/acq/source.c \
+	src/acq/channel.c
 
 REVISION ?= 1
 CFLAGS += -DBL_REVISION=$(REVISION)

--- a/bloodview/src/device.c
+++ b/bloodview/src/device.c
@@ -89,6 +89,7 @@ static void device__msg_advance_ptr(unsigned *pos)
 static inline union bl_msg_data *device__msg_get_next_free(void)
 {
 	if (locked_uint_is_equal(&bv_device_g.msg_used, MSG_FIFO_MAX)) {
+		fprintf(stderr, "No free slots to message device.\n");
 		return NULL;
 	}
 

--- a/bloodview/src/main-menu.c
+++ b/bloodview/src/main-menu.c
@@ -983,6 +983,11 @@ static bool main_menu__push_update(
 
 cleanup:
 	locked_uint_release(&update_ctx.count);
+	if (ret == false) {
+		if (type == UPDATE_TYPE_SET_VALUE) {
+			free(data->set_value.value);
+		}
+	}
 	return ret;
 }
 

--- a/bloodview/src/main-menu.h
+++ b/bloodview/src/main-menu.h
@@ -24,6 +24,8 @@
 #ifndef MAIN_MENU_H
 #define MAIN_MENU_H
 
+#include "../../src/acq.h"
+
 /**
  * Create the bloodlight main menu widget set.
  *
@@ -58,19 +60,44 @@ uint16_t main_menu_conifg_get_source_mask(void);
 uint16_t main_menu_conifg_get_frequency(void);
 
 /**
- * Get the oversample.
+ * Get the software oversample.
  *
- * \return the configured oversample.
+ * \param[in]  source  The source to read config from.
+ * \return the configured software oversample.
  */
-uint32_t main_menu_conifg_get_oversample(void);
+uint32_t main_menu_conifg_get_source_sw_oversample(enum bl_acq_source source);
 
 /**
- * Get the gain for a given channel.
+ * Get the opamp gain.
  *
- * \param[in]  channel  The channel to read config from.
- * \return the configured channel gain.
+ * \param[in]  source  The source to read config from.
+ * \return the configured opamp gain.
  */
-uint8_t main_menu_conifg_get_channel_gain(uint8_t channel);
+uint32_t main_menu_conifg_get_source_opamp_gain(enum bl_acq_source source);
+
+/**
+ * Get the opamp offset.
+ *
+ * \param[in]  source  The source to read config from.
+ * \return the configured opamp offset.
+ */
+uint32_t main_menu_conifg_get_source_opamp_offset(enum bl_acq_source source);
+
+/**
+ * Get the hardware oversample.
+ *
+ * \param[in]  source  The source to read config from.
+ * \return the configured hardware oversample.
+ */
+uint32_t main_menu_conifg_get_source_hw_oversample(enum bl_acq_source source);
+
+/**
+ * Get the hardware shift.
+ *
+ * \param[in]  source  The source to read config from.
+ * \return the configured hardware shift.
+ */
+uint32_t main_menu_conifg_get_source_hw_shift(enum bl_acq_source source);
 
 /**
  * Get the shift for a given channel.

--- a/run.sh
+++ b/run.sh
@@ -35,17 +35,26 @@ run_cal()
 	# Shine the lights
 	./tools/bl led     "$device" "$led_mask"
 
-	# chancfg <channel> <gain> [offset] [shift] [sample32]
-	./tools/bl chancfg "$device" 0 16  0  0  1 # Photodiode 1
-	./tools/bl chancfg "$device" 1  1  0  0  1 # Photodiode 2
-	./tools/bl chancfg "$device" 2  1  0  0  1 # Photodiode 3
-	./tools/bl chancfg "$device" 3  1  0  0  1 # Photodiode 4
-	./tools/bl chancfg "$device" 4  1  0  0  1 # 3.3V
-	./tools/bl chancfg "$device" 5  1  0  0  1 # 5.0V
-	./tools/bl chancfg "$device" 6  1  0  0  1 # Temperature
+	# srccfg <source> <gain> <offset> <sw oversample> [hw oversample] [hw shift]
+	./tools/bl srccfg "$device" 0 16 0 "$oversample" 0 0 # Photodiode 1
+	./tools/bl srccfg "$device" 1  1 0 "$oversample" 0 0 # Photodiode 2
+	./tools/bl srccfg "$device" 2  1 0 "$oversample" 0 0 # Photodiode 3
+	./tools/bl srccfg "$device" 3  1 0 "$oversample" 0 0 # Photodiode 4
+	./tools/bl srccfg "$device" 4  1 0 "$oversample" 0 0 # 3.3V
+	./tools/bl srccfg "$device" 5  1 0 "$oversample" 0 0 # 5.0V
+	./tools/bl srccfg "$device" 6  1 0 "$oversample" 0 0 # Temperature
+
+	# chancfg <channel> <source> [offset] [shift] [sample32]
+	./tools/bl chancfg "$device" 0 0  0  0  1 # Photodiode 1
+	./tools/bl chancfg "$device" 1 1  0  0  1 # Photodiode 2
+	./tools/bl chancfg "$device" 2 2  0  0  1 # Photodiode 3
+	./tools/bl chancfg "$device" 3 3  0  0  1 # Photodiode 4
+	./tools/bl chancfg "$device" 4 4  0  0  1 # 3.3V
+	./tools/bl chancfg "$device" 5 5  0  0  1 # 5.0V
+	./tools/bl chancfg "$device" 6 6  0  0  1 # Temperature
 
 	# Start the calibration acquisition.
-	./tools/bl start   "$device" "$frequency" "$oversample" "$src_mask"
+	./tools/bl start   "$device" "$frequency" "$src_mask"
 }
 
 # Run an acquisition.
@@ -60,25 +69,35 @@ run_acq()
 	# Shine the lights
 	./tools/bl led     "$device" "$led_mask"
 
-	# chancfg <channel> <gain> [offset] [shift] [sample32]
-	./tools/bl chancfg "$device" 0 16 1264480 0 # Photodiode 1
-	./tools/bl chancfg "$device" 1  1   54879 0 # Photodiode 2
-	./tools/bl chancfg "$device" 2  1  567447 0 # Photodiode 3
-	./tools/bl chancfg "$device" 3  1       0 0 # Photodiode 4
-	./tools/bl chancfg "$device" 4  1 1038856 0 # 3.3V
-	./tools/bl chancfg "$device" 5  1 1031704 0 # 5.0V
-	./tools/bl chancfg "$device" 6  1  860701 0 # Temperature
+	# srccfg <source> <gain> <offset> <sw oversample> [hw oversample] [hw shift]
+	./tools/bl srccfg "$device" 0 16 0 "$oversample" 0 0 # Photodiode 1
+	./tools/bl srccfg "$device" 1  1 0 "$oversample" 0 0 # Photodiode 2
+	./tools/bl srccfg "$device" 2  1 0 "$oversample" 0 0 # Photodiode 3
+	./tools/bl srccfg "$device" 3  1 0 "$oversample" 0 0 # Photodiode 4
+	./tools/bl srccfg "$device" 4  1 0 "$oversample" 0 0 # 3.3V
+	./tools/bl srccfg "$device" 5  1 0 "$oversample" 0 0 # 5.0V
+	./tools/bl srccfg "$device" 6  1 0 "$oversample" 0 0 # Temperature
+
+	# chancfg <channel> <source> [offset] [shift] [sample32]
+	./tools/bl chancfg "$device" 0 0 1264480 0 # Photodiode 1
+	./tools/bl chancfg "$device" 1 1   54879 0 # Photodiode 2
+	./tools/bl chancfg "$device" 2 2  567447 0 # Photodiode 3
+	./tools/bl chancfg "$device" 3 3       0 0 # Photodiode 4
+	./tools/bl chancfg "$device" 4 4 1038856 0 # 3.3V
+	./tools/bl chancfg "$device" 5 5 1031704 0 # 5.0V
+	./tools/bl chancfg "$device" 6 6  860701 0 # Temperature
 
 	# Start the calibration acquisition.
-	./tools/bl start   "$device" "$frequency" "$oversample" "$src_mask"
+	./tools/bl start   "$device" "$frequency" "$src_mask"
 }
 
-# Turn off the lights.
+# Turn off the lights and stop any acquisition.
 run_off()
 {
 	declare device="${DEVICE:-$DEFAULT_DEVICE}"
 
 	./tools/bl led     "$device" 0x0000
+	./tools/bl abort   "$device"
 }
 
 # Sequential exexute calibration and acquisition
@@ -114,7 +133,7 @@ run_cal_acq()
 	rm "$TMP_CFG"
 
 	# Start the calibration acquisition.
-	./tools/bl start   "$device" "$frequency" "$oversample" "$src_mask"
+	./tools/bl start   "$device" "$frequency" "$src_mask"
 }
 
 if [ $# -lt 1 ]; then

--- a/src/acq.h
+++ b/src/acq.h
@@ -55,19 +55,36 @@ void bl_acq_init(uint32_t clock);
  *
  * \param[in]  frequency   Sampling frequency.
  * \param[in]  src_mask    Mask of sources to enable.
- * \param[in]  oversample  Number of bits to oversample by.
  * \return \ref BL_ERROR_NONE on success, or appropriate error otherwise.
  */
 enum bl_error bl_acq_start(
 		uint16_t frequency,
-		uint32_t oversample,
 		uint16_t src_mask);
+
+/**
+ * Set the per-source configuration
+ *
+ * \param[in]  source         Channel (source) to configure
+ * \param[in]  opamp_gain     Hardware gain.
+ * \param[in]  opamp_offset   Hardware offset.
+ * \param[in]  sw_oversample  Software oversample.
+ * \param[in]  hw_oversample  Hardware oversample.
+ * \param[in]  hw_shift       Hardware shift.
+ * \return \ref BL_ERROR_NONE on success, or appropriate error otherwise.
+ */
+enum bl_error bl_acq_source_conf(
+		uint8_t  source,
+		uint8_t  opamp_gain,
+		uint16_t opamp_offset,
+		uint16_t sw_oversample,
+		uint8_t  hw_oversample,
+		uint8_t  hw_shift);
 
 /**
  * Set the per-channel configuration
  *
- * \param[in]  channel   Channel (source) to configure
- * \param[in]  gain      OpAMP gain to apply for the channel
+ * \param[in]  channel   Channel to configure
+ * \param[in]  source    Acquisition source associated with the channel.
  * \param[in]  shift     Bits to shift sample values by (divides by (2^shift)
  * \param[in]  offset    Amount to offset sample values by
  * \param[in]  saturate  Whether to enable sample saturation.
@@ -75,7 +92,7 @@ enum bl_error bl_acq_start(
  */
 enum bl_error bl_acq_channel_conf(
 		uint8_t  channel,
-		uint8_t  gain,
+		uint8_t  source,
 		uint8_t  shift,
 		uint32_t offset,
 		bool     sample32);

--- a/src/acq/adc.c
+++ b/src/acq/adc.c
@@ -1,6 +1,6 @@
 #include "adc.h"
 #include "rcc.h"
-#include "channel.h"
+#include "source.h"
 
 #include "../util.h"
 #include "../delay.h"
@@ -648,7 +648,7 @@ static void bl_acq_adc_dma_isr(bl_acq_adc_t *adc, unsigned buffer)
 	}
 
 	for (unsigned c = 0; c < adc->config.channel_count; c++) {
-		bl_acq_channel_commit_sample(
+		bl_acq_source_commit_sample(
 				adc->config.channel_index[c], sample[c]);
 	}
 }

--- a/src/acq/adc.c
+++ b/src/acq/adc.c
@@ -122,7 +122,7 @@ enum bl_error bl_acq_adc_group_configure(bl_acq_adc_group_t *adc_group,
 	}
 
 	if (frequency > max_freq) {
-		return BL_ERROR_OUT_OF_RANGE;
+		return BL_ERROR_ADC_FREQ_TOO_HIGH;
 	}
 
 	bl_acq_adc_group_config_t *config = &adc_group->config;
@@ -468,7 +468,7 @@ enum bl_error bl_acq_adc_configure(bl_acq_adc_t *adc,
 	}
 
 	if ((sw_oversample * config->channel_count) > BL_ACQ_DMA_MAX) {
-		return BL_ERROR_OUT_OF_RANGE;
+		return BL_ERROR_ADC_DMA_BUFFER;
 	}
 
 #if (BL_REVISION == 1)

--- a/src/acq/adc.c
+++ b/src/acq/adc.c
@@ -1,6 +1,7 @@
 #include "adc.h"
 #include "rcc.h"
 #include "source.h"
+#include "channel.h"
 
 #include "../util.h"
 #include "../delay.h"
@@ -199,7 +200,7 @@ typedef struct
 {
 	unsigned channel_count;
 	uint8_t  channel_adc[ADC_CHANNEL_COUNT];
-	uint8_t  channel_index[ADC_CHANNEL_COUNT];
+	uint8_t  channel_source[ADC_CHANNEL_COUNT];
 	uint8_t  smp[ADC_CHANNEL_COUNT];
 } bl_acq_adc_config_t;
 
@@ -397,12 +398,12 @@ void bl_acq_adc_calibrate(bl_acq_adc_t *adc)
 }
 
 enum bl_error bl_acq_adc_channel_configure(bl_acq_adc_t *adc,
-	uint8_t channel, uint8_t index)
+	uint8_t channel, uint8_t source)
 {
 	bl_acq_adc_config_t *config = &adc->config;
 
 	config->channel_adc[config->channel_count] = channel;
-	config->channel_index[config->channel_count] = index;
+	config->channel_source[config->channel_count] = source;
 	config->channel_count++;
 
 	return BL_ERROR_NONE;
@@ -648,8 +649,9 @@ static void bl_acq_adc_dma_isr(bl_acq_adc_t *adc, unsigned buffer)
 	}
 
 	for (unsigned c = 0; c < adc->config.channel_count; c++) {
-		bl_acq_source_commit_sample(
-				adc->config.channel_index[c], sample[c]);
+		unsigned channel = bl_acq_source_get_channel(
+				adc->config.channel_source[c]);
+		bl_acq_channel_commit_sample(channel, sample[c]);
 	}
 }
 

--- a/src/acq/adc.h
+++ b/src/acq/adc.h
@@ -30,7 +30,7 @@ extern bl_acq_adc_t *bl_acq_adc5;
 void bl_acq_adc_calibrate(bl_acq_adc_t *adc);
 
 enum bl_error bl_acq_adc_channel_configure(bl_acq_adc_t *adc,
-	uint8_t channel, uint8_t index);
+	uint8_t channel, uint8_t source);
 enum bl_error bl_acq_adc_configure(bl_acq_adc_t *adc,
 		uint32_t frequency, uint32_t sw_oversample,
 		uint8_t oversample, uint8_t shift);

--- a/src/acq/channel.c
+++ b/src/acq/channel.c
@@ -1,0 +1,168 @@
+#include "channel.h"
+#include "source.h"
+#include "opamp.h"
+#include "adc.h"
+
+#include "../mq.h"
+
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/adc.h>
+
+typedef struct  {
+	uint32_t sw_offset;
+	uint8_t  sw_shift;
+	bool     sample32;
+} bl_acq_channel_config_t;
+
+typedef struct
+{
+	enum bl_acq_source source;
+	unsigned           led;
+	bool               enable;
+
+	union bl_msg_data *msg;
+
+	bl_acq_channel_config_t config;
+} bl_acq_channel_t;
+
+static bl_acq_channel_t bl_acq_channel[BL_ACQ_CHANNEL_COUNT] = { 0 };
+
+enum bl_error bl_acq_channel_configure(unsigned channel,
+		enum bl_acq_source source,
+		bool sample32, uint32_t sw_offset, uint8_t sw_shift)
+{
+	bl_acq_channel_t *chan = &bl_acq_channel[channel];
+	bl_acq_channel_config_t *config = &chan->config;
+
+	chan->source = source;
+
+	config->sample32  = sample32;
+	config->sw_offset = sw_offset;
+	config->sw_shift  = sw_shift;
+	return BL_ERROR_NONE;
+}
+
+void bl_acq_channel_enable(unsigned channel)
+{
+	bl_acq_channel_t *chan = &bl_acq_channel[channel];
+
+	if (chan->enable) {
+		/* Already enabled. */
+		return;
+	}
+
+	bl_acq_source_enable(chan->source);
+
+	/* Initialize message queue. */
+	chan->msg = bl_mq_acquire(channel);
+	if (chan->msg != NULL) {
+		chan->msg->type = chan->config.sample32 ?
+			BL_MSG_SAMPLE_DATA32 : BL_MSG_SAMPLE_DATA16;
+		chan->msg->sample_data.channel  = channel;
+		chan->msg->sample_data.count    = 0;
+		chan->msg->sample_data.reserved = 0x00;
+	}
+
+	chan->enable = true;
+}
+
+void bl_acq_channel_disable(unsigned channel)
+{
+	bl_acq_channel_t *chan = &bl_acq_channel[channel];
+
+	bl_acq_source_disable(chan->source);
+
+	chan->enable = false;
+
+	/* Send remaining queued samples. */
+	union bl_msg_data *msg = chan->msg;
+	if (msg != NULL) {
+		bool pending;
+		switch (msg->type) {
+		case BL_MSG_SAMPLE_DATA16:
+		case BL_MSG_SAMPLE_DATA32:
+			pending = (msg->sample_data.count > 0);
+			break;
+		default:
+			pending = false;
+			break;
+		}
+
+		if (pending) {
+			bl_mq_commit(channel);
+		}
+
+		chan->msg = NULL;
+	}
+}
+
+bool bl_acq_channel_is_enabled(unsigned channel)
+{
+	bl_acq_channel_t *chan = &bl_acq_channel[channel];
+	return chan->enable;
+}
+
+
+enum bl_acq_source bl_acq_channel_get_source(unsigned channel)
+{
+	bl_acq_channel_t *chan = &bl_acq_channel[channel];
+	return chan->source;
+}
+
+static inline uint16_t bl_acq_sample_pack16(
+		uint32_t sample, uint32_t offset, uint8_t shift)
+{
+	if (sample < offset) return 0;
+	sample -= offset;
+	sample >>= shift;
+	return (sample > 0xFFFF) ? 0xFFFF : sample;
+}
+
+void bl_acq_channel_commit_sample(unsigned channel, uint32_t sample)
+{
+	bl_acq_channel_t *chan = &bl_acq_channel[channel];
+	const bl_acq_channel_config_t *config = &chan->config;
+
+	union bl_msg_data *msg = chan->msg;
+	/* Note: We don't check for NULL due to cost. */
+
+	if (config->sample32) {
+		uint8_t count = msg->sample_data.count++;
+		msg->sample_data.data32[count] = sample;
+
+		if (msg->sample_data.count >= MSG_SAMPLE_DATA32_MAX) {
+			bl_mq_commit(channel);
+			msg = bl_mq_acquire(channel);
+
+			/* Note: We dont' check for failure to acquire a msg
+			 * due to the cost of checking in an interrupt. */
+
+			msg->type = BL_MSG_SAMPLE_DATA32;
+			msg->sample_data.channel  = channel;
+			msg->sample_data.count    = 0;
+			msg->sample_data.reserved = 0;
+
+			chan->msg = msg;
+		}
+	} else {
+		uint8_t count = msg->sample_data.count++;
+		uint16_t sample16 = bl_acq_sample_pack16(sample,
+				config->sw_offset, config->sw_shift);
+		msg->sample_data.data16[count] = sample16;
+
+		if (msg->sample_data.count >= MSG_SAMPLE_DATA16_MAX) {
+			bl_mq_commit(channel);
+			msg = bl_mq_acquire(channel);
+
+			/* Note: We dont' check for failure to acquire a msg
+			 * due to the cost of checking in an interrupt. */
+
+			msg->type = BL_MSG_SAMPLE_DATA16;
+			msg->sample_data.channel  = channel;
+			msg->sample_data.count    = 0;
+			msg->sample_data.reserved = 0;
+
+			chan->msg = msg;
+		}
+	}
+}

--- a/src/acq/channel.h
+++ b/src/acq/channel.h
@@ -1,0 +1,25 @@
+#ifndef BL_ACQ_CHANNEL_H
+#define BL_ACQ_CHANNEL_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "../error.h"
+#include "../acq.h"
+
+#define BL_ACQ_CHANNEL_COUNT 16
+
+enum bl_error bl_acq_channel_configure(unsigned channel,
+		enum bl_acq_source source,
+		bool sample32, uint32_t sw_offset, uint8_t sw_shift);
+
+void bl_acq_channel_enable(unsigned channel);
+void bl_acq_channel_disable(unsigned channel);
+
+bool bl_acq_channel_is_enabled(unsigned channel);
+
+enum bl_acq_source bl_acq_channel_get_source(unsigned channel);
+
+void bl_acq_channel_commit_sample(unsigned channel, uint32_t sample);
+
+#endif

--- a/src/acq/dac.c
+++ b/src/acq/dac.c
@@ -58,11 +58,11 @@ enum bl_error bl_acq_dac_channel_configure(bl_acq_dac_t *dac,
 	}
 
 	if (channel > DAC_CHANNEL2) {
-		return BL_ERROR_OUT_OF_RANGE;
+		return BL_ERROR_DAC_BAD_CHANNEL;
 	}
 
 	if (offset > 0xFFF) {
-		return BL_ERROR_OUT_OF_RANGE;
+		return BL_ERROR_DAC_BAD_OFFSET;
 	}
 
 	bl_acq_dac_config_t *config = &dac->config;

--- a/src/acq/opamp.c
+++ b/src/acq/opamp.c
@@ -254,7 +254,7 @@ enum bl_error bl_acq_opamp_configure(bl_acq_opamp_t *opamp, uint8_t gain)
 #endif
 
 		default:
-			return BL_ERROR_OUT_OF_RANGE;
+			return BL_ERROR_OPAMP_BAD_GAIN;
 		}
 	} else {
 		switch (gain) {
@@ -285,7 +285,7 @@ enum bl_error bl_acq_opamp_configure(bl_acq_opamp_t *opamp, uint8_t gain)
 #endif
 
 		default:
-			return BL_ERROR_OUT_OF_RANGE;
+			return BL_ERROR_OPAMP_BAD_GAIN;
 		}
 	}
 

--- a/src/acq/source.c
+++ b/src/acq/source.c
@@ -285,7 +285,7 @@ bl_acq_source_config_t *bl_acq_source_get_config(enum bl_acq_source source)
 	return &src->config;
 }
 
-bl_acq_timer_t * bl_acq_source_get_timer(enum bl_acq_source source)
+bl_acq_timer_t *bl_acq_source_get_timer(enum bl_acq_source source)
 {
 	bl_acq_source_t *src = &bl_acq_source[source];
 
@@ -298,7 +298,7 @@ bl_acq_timer_t * bl_acq_source_get_timer(enum bl_acq_source source)
 	return bl_acq_adc_get_timer(*(src->adc));
 }
 
-bl_acq_opamp_t * bl_acq_source_get_opamp(enum bl_acq_source source)
+bl_acq_opamp_t *bl_acq_source_get_opamp(enum bl_acq_source source)
 {
 	bl_acq_source_t *src = &bl_acq_source[source];
 
@@ -310,7 +310,7 @@ bl_acq_opamp_t * bl_acq_source_get_opamp(enum bl_acq_source source)
 }
 
 #if (BL_REVISION >= 2)
-bl_acq_dac_t * bl_acq_source_get_dac(enum bl_acq_source source,
+bl_acq_dac_t *bl_acq_source_get_dac(enum bl_acq_source source,
 	uint8_t *dac_channel)
 {
 	bl_acq_opamp_t *opamp = bl_acq_source_get_opamp(source);
@@ -322,7 +322,7 @@ bl_acq_dac_t * bl_acq_source_get_dac(enum bl_acq_source source,
 }
 #endif
 
-bl_acq_adc_t * bl_acq_source_get_adc(enum bl_acq_source source,
+bl_acq_adc_t *bl_acq_source_get_adc(enum bl_acq_source source,
 	uint8_t *adc_channel)
 {
 	bl_acq_source_t *src = &bl_acq_source[source];

--- a/src/acq/source.c
+++ b/src/acq/source.c
@@ -16,7 +16,7 @@ typedef struct
 	bl_acq_adc_t   **adc;
 	uint8_t          adc_channel;
 	uint32_t         adc_ccr_flag;
-	bool             enable;
+	uint32_t         enable;
 
 	union bl_msg_data *msg;
 
@@ -34,7 +34,7 @@ static bl_acq_source_t bl_acq_source[] =
 		.adc          = &bl_acq_adc2,
 		.adc_channel  = 1,
 		.adc_ccr_flag = 0,
-		.enable       = false,
+		.enable       = 0,
 	},
 	[BL_ACQ_PD2] = {
 		.gpio_port    = GPIOA,
@@ -44,7 +44,7 @@ static bl_acq_source_t bl_acq_source[] =
 		.adc          = &bl_acq_adc1,
 		.adc_channel  = 4,
 		.adc_ccr_flag = 0,
-		.enable       = false,
+		.enable       = 0,
 	},
 	[BL_ACQ_PD3] = {
 		.gpio_port    = GPIOA,
@@ -54,7 +54,7 @@ static bl_acq_source_t bl_acq_source[] =
 		.adc          = &bl_acq_adc2,
 		.adc_channel  = 4,
 		.adc_ccr_flag = 0,
-		.enable       = false,
+		.enable       = 0,
 	},
 	[BL_ACQ_PD4] = {
 		.gpio_port    = GPIOA,
@@ -64,7 +64,7 @@ static bl_acq_source_t bl_acq_source[] =
 		.adc          = &bl_acq_adc2,
 		.adc_channel  = 2,
 		.adc_ccr_flag = 0,
-		.enable       = false,
+		.enable       = 0,
 	},
 	[BL_ACQ_3V3] = {
 		.gpio_port    = GPIOA,
@@ -74,7 +74,7 @@ static bl_acq_source_t bl_acq_source[] =
 		.adc          = &bl_acq_adc1,
 		.adc_channel  = 2,
 		.adc_ccr_flag = 0,
-		.enable       = false,
+		.enable       = 0,
 	},
 	[BL_ACQ_5V0] = {
 		.gpio_port    = GPIOA,
@@ -84,7 +84,7 @@ static bl_acq_source_t bl_acq_source[] =
 		.adc          = &bl_acq_adc1,
 		.adc_channel  = 3,
 		.adc_ccr_flag = 0,
-		.enable       = false,
+		.enable       = 0,
 	},
 	[BL_ACQ_TMP] = {
 		.gpio_port    = 0,
@@ -93,7 +93,7 @@ static bl_acq_source_t bl_acq_source[] =
 		.adc          = &bl_acq_adc1,
 		.adc_channel  = ADC_CHANNEL_TEMP,
 		.adc_ccr_flag = ADC_CCR_TSEN,
-		.enable       = false,
+		.enable       = 0,
 	},
 #else
 	[BL_ACQ_PD1] = {
@@ -102,7 +102,7 @@ static bl_acq_source_t bl_acq_source[] =
 		.opamp        = &bl_acq_opamp3,
 		.opamp_used   = true,
 		.adc          = NULL,
-		.enable       = false,
+		.enable       = 0,
 	},
 	[BL_ACQ_PD2] = {
 		.gpio_port    = GPIOB,
@@ -110,7 +110,7 @@ static bl_acq_source_t bl_acq_source[] =
 		.opamp        = &bl_acq_opamp4,
 		.opamp_used   = true,
 		.adc          = NULL,
-		.enable       = false,
+		.enable       = 0,
 	},
 	[BL_ACQ_PD3] = {
 		.gpio_port    = GPIOB,
@@ -118,7 +118,7 @@ static bl_acq_source_t bl_acq_source[] =
 		.opamp        = &bl_acq_opamp6,
 		.opamp_used   = true,
 		.adc          = NULL,
-		.enable       = false,
+		.enable       = 0,
 	},
 	[BL_ACQ_PD4] = {
 		.gpio_port    = GPIOA,
@@ -126,7 +126,7 @@ static bl_acq_source_t bl_acq_source[] =
 		.opamp        = &bl_acq_opamp1,
 		.opamp_used   = true,
 		.adc          = NULL,
-		.enable       = false,
+		.enable       = 0,
 	},
 	[BL_ACQ_3V3] = {
 		.gpio_port    = 0,
@@ -135,7 +135,7 @@ static bl_acq_source_t bl_acq_source[] =
 		.adc          = &bl_acq_adc1,
 		.adc_channel  = ADC_CHANNEL_VBAT,
 		.adc_ccr_flag = ADC_CCR_VBATEN,
-		.enable       = false,
+		.enable       = 0,
 	},
 	[BL_ACQ_5V0] = {
 		.gpio_port    = GPIOA,
@@ -145,7 +145,7 @@ static bl_acq_source_t bl_acq_source[] =
 		.adc          = &bl_acq_adc2,
 		.adc_channel  = 4,
 		.adc_ccr_flag = 0,
-		.enable       = false,
+		.enable       = 0,
 	},
 	[BL_ACQ_TMP] = {
 		.gpio_port    = 0,
@@ -154,7 +154,7 @@ static bl_acq_source_t bl_acq_source[] =
 		.adc          = &bl_acq_adc1,
 		.adc_channel  = ADC_CHANNEL_TEMP,
 		.adc_ccr_flag = ADC_CCR_TSEN,
-		.enable       = false,
+		.enable       = 0,
 	},
 	[BL_ACQ_EXT] = {
 		.gpio_port    = GPIOB,
@@ -162,7 +162,7 @@ static bl_acq_source_t bl_acq_source[] =
 		.opamp        = &bl_acq_opamp5,
 		.opamp_used   = true,
 		.adc          = NULL,
-		.enable       = false,
+		.enable       = 0,
 	},
 #endif
 };
@@ -199,7 +199,8 @@ void bl_acq_source_enable(enum bl_acq_source source)
 {
 	bl_acq_source_t *src = &bl_acq_source[source];
 
-	if (src->enable) {
+	src->enable++;
+	if (src->enable > 1) {
 		/* Already enabled. */
 		return;
 	}
@@ -226,13 +227,20 @@ void bl_acq_source_enable(enum bl_acq_source source)
 		src->msg->sample_data.count    = 0;
 		src->msg->sample_data.reserved = 0x00;
 	}
-
-	src->enable = true;
 }
 
 void bl_acq_source_disable(enum bl_acq_source source)
 {
 	bl_acq_source_t *src = &bl_acq_source[source];
+
+	if (src->enable == 0) {
+		return;
+	}
+
+	src->enable--;
+	if (src->enable > 0) {
+		return;
+	}
 
 	if ((src->adc != NULL) && (src->config.opamp_gain <= 1)) {
 		bl_acq_adc_disable(*(src->adc), src->adc_ccr_flag);
@@ -241,8 +249,6 @@ void bl_acq_source_disable(enum bl_acq_source source)
 	}
 
 	/* Don't need to do anything here to disable GPIO (it is floating). */
-
-	src->enable = false;
 
 	/* Send remaining queued samples. */
 	union bl_msg_data *msg = src->msg;
@@ -283,10 +289,6 @@ bl_acq_timer_t * bl_acq_source_get_timer(enum bl_acq_source source)
 {
 	bl_acq_source_t *src = &bl_acq_source[source];
 
-	if (!src->config.enable) {
-		return NULL;
-	}
-
 	if (src->opamp_used) {
 		bl_acq_adc_t *adc = bl_acq_opamp_get_adc(
 				*(src->opamp), NULL);
@@ -300,7 +302,7 @@ bl_acq_opamp_t * bl_acq_source_get_opamp(enum bl_acq_source source)
 {
 	bl_acq_source_t *src = &bl_acq_source[source];
 
-	if (!src->config.enable || !src->opamp_used) {
+	if (!src->opamp_used) {
 		return NULL;
 	}
 
@@ -324,10 +326,6 @@ bl_acq_adc_t * bl_acq_source_get_adc(enum bl_acq_source source,
 	uint8_t *adc_channel)
 {
 	bl_acq_source_t *src = &bl_acq_source[source];
-
-	if (!src->config.enable) {
-		return NULL;
-	}
 
 	if (src->opamp_used) {
 		return bl_acq_opamp_get_adc(*(src->opamp), adc_channel);

--- a/src/acq/source.h
+++ b/src/acq/source.h
@@ -1,5 +1,5 @@
-#ifndef BL_ACQ_CHANNEL_H
-#define BL_ACQ_CHANNEL_H
+#ifndef BL_ACQ_SOURCE_H
+#define BL_ACQ_SOURCE_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -38,37 +38,37 @@ typedef struct  {
 	uint8_t  sw_shift;
 
 	bool     sample32;
-} bl_acq_channel_config_t;
+} bl_acq_source_config_t;
 
 
-void bl_acq_channel_calibrate(enum bl_acq_source source);
+void bl_acq_source_calibrate(enum bl_acq_source source);
 
-enum bl_error bl_acq_channel_configure(enum bl_acq_source source);
+enum bl_error bl_acq_source_configure(enum bl_acq_source source);
 
-void bl_acq_channel_enable(enum bl_acq_source source);
-void bl_acq_channel_disable(enum bl_acq_source source);
+void bl_acq_source_enable(enum bl_acq_source source);
+void bl_acq_source_disable(enum bl_acq_source source);
 
-bool bl_acq_channel_is_enabled(enum bl_acq_source source);
+bool bl_acq_source_is_enabled(enum bl_acq_source source);
 
-bl_acq_channel_config_t *bl_acq_channel_get_config(enum bl_acq_source source);
+bl_acq_source_config_t *bl_acq_source_get_config(enum bl_acq_source source);
 
 #include "timer.h"
-bl_acq_timer_t *bl_acq_channel_get_timer(enum bl_acq_source source);
+bl_acq_timer_t *bl_acq_source_get_timer(enum bl_acq_source source);
 
 #include "opamp.h"
-bl_acq_opamp_t *bl_acq_channel_get_opamp(enum bl_acq_source source);
+bl_acq_opamp_t *bl_acq_source_get_opamp(enum bl_acq_source source);
 
 #if (BL_REVISION >= 2)
 #include "dac.h"
-bl_acq_dac_t *bl_acq_channel_get_dac(enum bl_acq_source source,
+bl_acq_dac_t *bl_acq_source_get_dac(enum bl_acq_source source,
 		uint8_t *dac_channel);
 #endif
 
 #include "adc.h"
-bl_acq_adc_t *bl_acq_channel_get_adc(enum bl_acq_source source,
+bl_acq_adc_t *bl_acq_source_get_adc(enum bl_acq_source source,
 		uint8_t *adc_channel);
 
-void bl_acq_channel_commit_sample(enum bl_acq_source source, uint32_t sample);
+void bl_acq_source_commit_sample(enum bl_acq_source source, uint32_t sample);
 
 #endif
 

--- a/src/acq/source.h
+++ b/src/acq/source.h
@@ -34,16 +34,14 @@ typedef struct  {
 	/* TODO: Support hardware gain compensation and offset in ADC? */
 
 	uint16_t sw_oversample;
-	uint32_t sw_offset;
-	uint8_t  sw_shift;
-
-	bool     sample32;
 } bl_acq_source_config_t;
 
 
 void bl_acq_source_calibrate(enum bl_acq_source source);
 
 enum bl_error bl_acq_source_configure(enum bl_acq_source source);
+
+void bl_acq_source_assign_channel(enum bl_acq_source source, unsigned channel);
 
 void bl_acq_source_enable(enum bl_acq_source source);
 void bl_acq_source_disable(enum bl_acq_source source);
@@ -68,7 +66,7 @@ bl_acq_dac_t *bl_acq_source_get_dac(enum bl_acq_source source,
 bl_acq_adc_t *bl_acq_source_get_adc(enum bl_acq_source source,
 		uint8_t *adc_channel);
 
-void bl_acq_source_commit_sample(enum bl_acq_source source, uint32_t sample);
+uint8_t bl_acq_source_get_channel(enum bl_acq_source source);
 
 #endif
 

--- a/src/acq/timer.c
+++ b/src/acq/timer.c
@@ -54,7 +54,7 @@ enum bl_error bl_acq_timer_configure(bl_acq_timer_t *timer, uint32_t frequency)
 	}
 
 	if ((frequency == 0) || (frequency > bl_acq_timer__bus_freq)) {
-		return BL_ERROR_OUT_OF_RANGE;
+		return BL_ERROR_TIMER_BAD_FREQUENCY;
 	}
 
 	uint32_t ticks_per_sample = DIV_NEAREST(

--- a/src/error.h
+++ b/src/error.h
@@ -19,15 +19,21 @@
 
 /** Error codes. */
 enum bl_error {
-	BL_ERROR_NONE,               /**< Success. */
-	BL_ERROR_OUT_OF_RANGE,       /**< Value is out of allowed range. */
-	BL_ERROR_BAD_MESSAGE_TYPE,   /**< Unknown message type. */
-	BL_ERROR_BAD_MESSAGE_LENGTH, /**< Unexpected message length. */
-	BL_ERROR_BAD_SOURCE_MASK,    /**< No sources would be sampled. */
-	BL_ERROR_ACTIVE_ACQUISITION, /**< There is an active acquisition. */
-	BL_ERROR_BAD_FREQUENCY,      /**< Frequency combo not supported. */
-	BL_ERROR_NOT_IMPLEMENTED,    /**< Feature not implemented. */
-	BL_ERROR_HARDWARE_CONFLICT,  /**< Hardware conflict in config. */
+	BL_ERROR_NONE,                /**< Success. */
+	BL_ERROR_OUT_OF_RANGE,        /**< Value is out of allowed range. */
+	BL_ERROR_BAD_MESSAGE_TYPE,    /**< Unknown message type. */
+	BL_ERROR_BAD_MESSAGE_LENGTH,  /**< Unexpected message length. */
+	BL_ERROR_BAD_SOURCE_MASK,     /**< No sources would be sampled. */
+	BL_ERROR_ACTIVE_ACQUISITION,  /**< There is an active acquisition. */
+	BL_ERROR_BAD_FREQUENCY,       /**< Frequency combo not supported. */
+	BL_ERROR_NOT_IMPLEMENTED,     /**< Feature not implemented. */
+	BL_ERROR_HARDWARE_CONFLICT,   /**< Hardware conflict in config. */
+	BL_ERROR_ADC_FREQ_TOO_HIGH,   /**< Frequency too high for ADC. */
+	BL_ERROR_ADC_DMA_BUFFER,      /**< Config exceeds DMA buffer size. */
+	BL_ERROR_DAC_BAD_CHANNEL,     /**< Bad DAC channel. */
+	BL_ERROR_DAC_BAD_OFFSET,      /**< Bad DAC offset. */
+	BL_ERROR_OPAMP_BAD_GAIN,      /**< Bad opamp gain. */
+	BL_ERROR_TIMER_BAD_FREQUENCY, /**< Bad timer frequency. */
 };
 
 #endif

--- a/src/mq.c
+++ b/src/mq.c
@@ -2,18 +2,28 @@
 #include <stddef.h>
 
 #include "mq.h"
+#include "util.h"
 
 #define BL_MSG_QUEUE_COUNT 64
 
+#if (BL_MSG_QUEUE_COUNT % BL_ACQ_CHANNEL_COUNT)
+#warning "Message queue size should be a multiple of channel count"
+#endif
+
+#if (BL_MSG_QUEUE_COUNT / BL_ACQ_CHANNEL_COUNT < 2)
+#error "Message queue must have at least two queues per channel."
+#endif
+
 static union bl_msg_data msg[BL_MSG_QUEUE_COUNT];
-struct mq_ctx mq_ctx[BL_ACQ__SRC_COUNT];
-volatile unsigned mq_pending;
+struct mq_ctx mq_ctx[BL_ACQ_CHANNEL_COUNT];
+
+volatile uint32_t mq_pending;
 
 void bl_mq_init(void)
 {
-	uint8_t max = BL_MSG_QUEUE_COUNT / BL_ACQ__SRC_COUNT;
+	uint8_t max = BL_ARRAY_LEN(msg) / BL_ARRAY_LEN(mq_ctx);
 
-	for (unsigned i = 0; i < BL_ACQ__SRC_COUNT; i++) {
+	for (unsigned i = 0; i < BL_ARRAY_LEN(mq_ctx); i++) {
 		mq_ctx[i].msg   = &msg[i * max];
 		mq_ctx[i].max   = max;
 		mq_ctx[i].read  = 0;

--- a/src/mq.h
+++ b/src/mq.h
@@ -18,6 +18,7 @@
 #define BL_MQ_H
 
 #include "msg.h"
+#include "acq/channel.h"
 
 struct mq_ctx {
 	union bl_msg_data *msg;
@@ -27,8 +28,8 @@ struct mq_ctx {
 	volatile uint8_t write;
 };
 
-extern struct mq_ctx mq_ctx[BL_ACQ__SRC_COUNT];
-extern volatile unsigned mq_pending;
+extern struct mq_ctx mq_ctx[BL_ACQ_CHANNEL_COUNT];
+extern volatile uint32_t mq_pending;
 
 void bl_mq_init(void);
 

--- a/src/msg.c
+++ b/src/msg.c
@@ -34,6 +34,23 @@ static enum bl_error bl_msg_led(const union bl_msg_data *msg)
 }
 
 /**
+ * Handle the source config message.
+ *
+ * \param[in]  msg  Message to handle.
+ * \return \ref BL_ERROR_NONE on success, or appropriate error otherwise.
+ */
+static enum bl_error bl_msg_source_conf(const union bl_msg_data *msg)
+{
+	return bl_acq_source_conf(
+			msg->source_conf.source,
+			msg->source_conf.opamp_gain,
+			msg->source_conf.opamp_offset,
+			msg->source_conf.sw_oversample,
+			msg->source_conf.hw_oversample,
+			msg->source_conf.hw_shift);
+}
+
+/**
  * Handle the channel config message.
  *
  * \param[in]  msg  Message to handle.
@@ -43,7 +60,7 @@ static enum bl_error bl_msg_channel_conf(const union bl_msg_data *msg)
 {
 	return bl_acq_channel_conf(
 			msg->channel_conf.channel,
-			msg->channel_conf.gain,
+			msg->channel_conf.source,
 			msg->channel_conf.shift,
 			msg->channel_conf.offset,
 			(msg->channel_conf.sample32 != 0));
@@ -59,7 +76,6 @@ static enum bl_error bl_msg_start(const union bl_msg_data *msg)
 {
 	return bl_acq_start(
 			msg->start.frequency,
-			msg->start.oversample,
 			msg->start.src_mask);
 }
 
@@ -86,6 +102,7 @@ enum bl_error bl_msg_handle(const union bl_msg_data *msg)
 		[BL_MSG_LED]          = bl_msg_led,
 		[BL_MSG_START]        = bl_msg_start,
 		[BL_MSG_ABORT]        = bl_msg_abort,
+		[BL_MSG_SOURCE_CONF]  = bl_msg_source_conf,
 		[BL_MSG_CHANNEL_CONF] = bl_msg_channel_conf,
 	};
 

--- a/src/msg.h
+++ b/src/msg.h
@@ -36,6 +36,7 @@
 enum bl_msg_type {
 	BL_MSG_RESPONSE,
 	BL_MSG_LED,
+	BL_MSG_SOURCE_CONF,
 	BL_MSG_CHANNEL_CONF,
 	BL_MSG_START,
 	BL_MSG_ABORT,
@@ -69,8 +70,18 @@ typedef struct {
 
 typedef struct {
 	uint8_t  type;
+	uint8_t  source;
+	uint8_t  opamp_gain;
+	uint16_t opamp_offset;
+	uint16_t sw_oversample;
+	uint8_t  hw_oversample;
+	uint8_t  hw_shift;
+} bl_msg_source_conf_t;
+
+typedef struct {
+	uint8_t  type;
 	uint8_t  channel;
-	uint8_t  gain;
+	uint8_t  source;
 	uint8_t  shift;
 	uint32_t offset;
 	uint8_t  sample32;
@@ -82,7 +93,6 @@ typedef struct {
 typedef struct {
 	uint8_t  type;       /**< Must be \ref BL_MSG_SETUP */
 	uint16_t frequency;  /**< Sampling rate in Hz. */
-	uint32_t oversample; /**< Numver of sample readings per sample */
 	uint16_t src_mask;   /**< Mask of sources to enable. */
 } bl_msg_start_t;
 
@@ -111,6 +121,7 @@ union bl_msg_data {
 
 	bl_msg_response_t     response;
 	bl_msg_led_t          led;
+	bl_msg_source_conf_t  source_conf;
 	bl_msg_channel_conf_t channel_conf;
 	bl_msg_start_t        start;
 	bl_msg_abort_t        abort;
@@ -140,6 +151,7 @@ static inline uint8_t bl_msg_type_to_len(enum bl_msg_type type)
 	static const uint8_t len_table[BL_MSG__COUNT] = {
 		[BL_MSG_RESPONSE]      = BL_SIZEOF_MSG(response),
 		[BL_MSG_LED]           = BL_SIZEOF_MSG(led),
+		[BL_MSG_SOURCE_CONF]   = BL_SIZEOF_MSG(source_conf),
 		[BL_MSG_CHANNEL_CONF]  = BL_SIZEOF_MSG(channel_conf),
 		[BL_MSG_START]         = BL_SIZEOF_MSG(start),
 		[BL_MSG_ABORT]         = BL_SIZEOF_MSG(abort),

--- a/src/msg.h
+++ b/src/msg.h
@@ -54,15 +54,15 @@ typedef struct {
 } bl_msg_response_t;
 
 /**
-	* Data for \ref BL_MSG_LED.
-	*
-	* This simply turns LEDs on and off.
-	*
-	* While the interface allows multiple LEDs to be on simultaniously,
-	* it may not be possible to achieve on the hardware, due to power
-	* limitations.  Setting a value of 0x00 turns all LEDs off.  The
-	* least significant bit is LD1.
-	*/
+ * Data for \ref BL_MSG_LED.
+ *
+ * This simply turns LEDs on and off.
+ *
+ * While the interface allows multiple LEDs to be on simultaniously,
+ * it may not be possible to achieve on the hardware, due to power
+ * limitations.  Setting a value of 0x00 turns all LEDs off.  The
+ * least significant bit is LD1.
+ */
 typedef struct {
 	uint8_t  type;     /**< Must be \ref BL_MSG_LED */
 	uint16_t led_mask; /**< One bit per LED. */
@@ -88,10 +88,10 @@ typedef struct {
 } bl_msg_channel_conf_t;
 
 /**
-	* Data for \ref BL_MSG_SETUP.
-	*/
+ * Data for \ref BL_MSG_START.
+ */
 typedef struct {
-	uint8_t  type;       /**< Must be \ref BL_MSG_SETUP */
+	uint8_t  type;       /**< Must be \ref BL_MSG_START */
 	uint16_t frequency;  /**< Sampling rate in Hz. */
 	uint16_t src_mask;   /**< Mask of sources to enable. */
 } bl_msg_start_t;
@@ -101,7 +101,7 @@ typedef struct {
 	uint8_t type; /**< Must be \ref BL_MSG_ABORT */
 } bl_msg_abort_t;
 
-/** Data for \ref BL_MSG_SAMPLE_DATA16. */
+/** Data for \ref BL_MSG_SAMPLE_DATA16 and \ref BL_MSG_SAMPLE_DATA32. */
 typedef struct {
 	uint8_t  type;     /**< Must be \ref BL_MSG_SAMPLE_DATA */
 	uint8_t  channel;  /**< Channel of sample data. */

--- a/tools/bl.c
+++ b/tools/bl.c
@@ -95,7 +95,7 @@ static int bl_cmd_led(int argc, char *argv[])
 	bl_msg_yaml_print(stdout, &msg);
 	if (!bl_msg_write(dev_fd, argv[ARG_DEV_PATH], &msg)) {
 		bl_device_close(dev_fd);
-		return ret;
+		return EXIT_FAILURE;
 	}
 	ret = bl_cmd_read_and_print_message(dev_fd, 10000);
 	bl_device_close(dev_fd);
@@ -196,7 +196,7 @@ static int bl_cmd_channel_conf(int argc, char *argv[])
 	bl_msg_yaml_print(stdout, &msg);
 	if (!bl_msg_write(dev_fd, argv[ARG_DEV_PATH], &msg)) {
 		bl_device_close(dev_fd);
-		return ret;
+		return EXIT_FAILURE;
 	}
 	ret = bl_cmd_read_and_print_message(dev_fd, 10000);
 	bl_device_close(dev_fd);
@@ -300,7 +300,7 @@ static int bl_cmd_source_conf(int argc, char *argv[])
 	bl_msg_yaml_print(stdout, &msg);
 	if (!bl_msg_write(dev_fd, argv[ARG_DEV_PATH], &msg)) {
 		bl_device_close(dev_fd);
-		return ret;
+		return EXIT_FAILURE;
 	}
 	ret = bl_cmd_read_and_print_message(dev_fd, 10000);
 	bl_device_close(dev_fd);
@@ -339,7 +339,7 @@ static int bl_cmd__no_params_helper(
 	bl_msg_yaml_print(stdout, &msg);
 	if (!bl_msg_write(dev_fd, argv[ARG_DEV_PATH], &msg)) {
 		bl_device_close(dev_fd);
-		return ret;
+		return EXIT_FAILURE;
 	}
 	ret = bl_cmd_read_and_print_message(dev_fd, 10000);
 	bl_device_close(dev_fd);

--- a/tools/calibrate.c
+++ b/tools/calibrate.c
@@ -33,7 +33,7 @@
 struct channel_conf {
 	bool     enabled;
 
-	uint8_t  gain;
+	uint8_t  source;
 	uint8_t  shift;
 	uint32_t offset;
 
@@ -100,7 +100,7 @@ static void bl__handle_channel_conf(
 	/* Channel is only enabled if we receive sample32. */
 	conf[channel].enabled = false;
 
-	conf[channel].gain   = msg->channel_conf.gain;
+	conf[channel].source = msg->channel_conf.source;
 	conf[channel].shift  = msg->channel_conf.shift;
 	conf[channel].offset = msg->channel_conf.offset;
 
@@ -164,7 +164,7 @@ static int bl__calibrate(void)
 	for (unsigned i = 0; i < BL_ACQ__SRC_COUNT; i++) {
 		if (conf[i].enabled) {
 			printf("./tools/bl chancfg \"$device\" %u %u %u %u\n", i,
-					(unsigned) conf[i].gain,
+					(unsigned) conf[i].source,
 					(unsigned) conf[i].offset,
 					(unsigned) conf[i].shift);
 		}

--- a/tools/msg.c
+++ b/tools/msg.c
@@ -42,6 +42,7 @@ static char buffer[BUFFER_LEN + 1];
 static const char *msg_types[] = {
 	[BL_MSG_RESPONSE]      = "Response",
 	[BL_MSG_LED]           = "LED",
+	[BL_MSG_SOURCE_CONF]   = "Source Config",
 	[BL_MSG_CHANNEL_CONF]  = "Channel Config",
 	[BL_MSG_START]         = "Start",
 	[BL_MSG_ABORT]         = "Abort",
@@ -155,7 +156,7 @@ static uint16_t bl_msg__yaml_read_unsigned(FILE *file, const char *field, bool *
 	unsigned value;
 	int ret;
 
-	ret = fscanf(file, "%"BUFFER_LEN_STR"[A-Za-z0-9 ]: %u\n",
+	ret = fscanf(file, "%"BUFFER_LEN_STR"[A-Za-z0-9 -]: %u\n",
 			buffer, &value);
 	if (ret == 2) {
 		if (strcmp(buffer, field) == 0) {
@@ -172,7 +173,7 @@ static uint16_t bl_msg__yaml_read_hex(FILE *file, const char *field, bool *succe
 	unsigned value;
 	int ret;
 
-	ret = fscanf(file, "%"BUFFER_LEN_STR"[A-Za-z0-9 ]: 0x%x\n",
+	ret = fscanf(file, "%"BUFFER_LEN_STR"[A-Za-z0-9 -]: 0x%x\n",
 			buffer, &value);
 	if (ret == 2) {
 		if (strcmp(buffer, field) == 0) {
@@ -216,18 +217,26 @@ bool bl_msg_yaml_parse(FILE *file, union bl_msg_data *msg)
 		msg->led.led_mask = bl_msg__yaml_read_hex(file, "LED Mask", &ok);
 		break;
 
+	case BL_MSG_SOURCE_CONF:
+		msg->source_conf.source        = bl_msg__yaml_read_unsigned(file, "Source",              &ok);
+		msg->source_conf.opamp_gain    = bl_msg__yaml_read_unsigned(file, "Op-Amp Gain",         &ok);
+		msg->source_conf.opamp_offset  = bl_msg__yaml_read_unsigned(file, "Op-Amp Offset",       &ok);
+		msg->source_conf.sw_oversample = bl_msg__yaml_read_unsigned(file, "Software Oversample", &ok);
+		msg->source_conf.hw_oversample = bl_msg__yaml_read_unsigned(file, "Hardware Oversample", &ok);
+		msg->source_conf.hw_shift      = bl_msg__yaml_read_unsigned(file, "Hardware Shift",      &ok);
+		break;
+
 	case BL_MSG_CHANNEL_CONF:
 		msg->channel_conf.channel  = bl_msg__yaml_read_unsigned(file, "Channel",  &ok);
-		msg->channel_conf.gain     = bl_msg__yaml_read_unsigned(file, "Gain",     &ok);
+		msg->channel_conf.source   = bl_msg__yaml_read_unsigned(file, "Source",   &ok);
 		msg->channel_conf.shift    = bl_msg__yaml_read_unsigned(file, "Shift",    &ok);
 		msg->channel_conf.offset   = bl_msg__yaml_read_unsigned(file, "Offset",   &ok);
 		msg->channel_conf.sample32 = bl_msg__yaml_read_unsigned(file, "Sample32", &ok);
 		break;
 
 	case BL_MSG_START:
-		msg->start.frequency  = bl_msg__yaml_read_unsigned(file, "Frequency",  &ok);
-		msg->start.oversample = bl_msg__yaml_read_unsigned(file, "Oversample", &ok);
-		msg->start.src_mask   = bl_msg__yaml_read_hex(file, "Source Mask",     &ok);
+		msg->start.frequency  = bl_msg__yaml_read_unsigned(file, "Frequency",   &ok);
+		msg->start.src_mask   = bl_msg__yaml_read_hex(file,      "Source Mask", &ok);
 		break;
 
 	case BL_MSG_SAMPLE_DATA16:
@@ -301,11 +310,26 @@ void bl_msg_yaml_print(FILE *file, const union bl_msg_data *msg)
 				msg->led.led_mask);
 		break;
 
+	case BL_MSG_SOURCE_CONF:
+		fprintf(file, "    Source: %"PRIu8"\n",
+				msg->source_conf.source);
+		fprintf(file, "    Op-Amp Gain: %"PRIu8"\n",
+				msg->source_conf.opamp_gain);
+		fprintf(file, "    Op-Amp Offset: %"PRIu16"\n",
+				msg->source_conf.opamp_offset);
+		fprintf(file, "    Software Oversample: %"PRIu16"\n",
+				msg->source_conf.sw_oversample);
+		fprintf(file, "    Hardware Oversample: %"PRIu8"\n",
+				msg->source_conf.hw_oversample);
+		fprintf(file, "    Hardware Shift: %"PRIu8"\n",
+				msg->source_conf.hw_shift);
+		break;
+
 	case BL_MSG_CHANNEL_CONF:
 		fprintf(file, "    Channel: %"PRIu8"\n",
 				msg->channel_conf.channel);
-		fprintf(file, "    Gain: %"PRIu8"\n",
-				msg->channel_conf.gain);
+		fprintf(file, "    Source: %"PRIu8"\n",
+				msg->channel_conf.source);
 		fprintf(file, "    Shift: %"PRIu8"\n",
 				msg->channel_conf.shift);
 		fprintf(file, "    Offset: %"PRIu32"\n",
@@ -317,8 +341,6 @@ void bl_msg_yaml_print(FILE *file, const union bl_msg_data *msg)
 	case BL_MSG_START:
 		fprintf(file, "    Frequency: %"PRIu8"\n",
 				msg->start.frequency);
-		fprintf(file, "    Oversample: %"PRIu8"\n",
-				msg->start.oversample);
 		fprintf(file, "    Source Mask: 0x%"PRIx8"\n",
 				msg->start.src_mask);
 		break;

--- a/tools/msg.c
+++ b/tools/msg.c
@@ -52,15 +52,21 @@ static const char *msg_types[] = {
 
 /** Message type to string mapping, */
 static const char *msg_errors[] = {
-	[BL_ERROR_NONE]               = "Success",
-	[BL_ERROR_OUT_OF_RANGE]       = "Value out of range",
-	[BL_ERROR_BAD_MESSAGE_TYPE]   = "Bad message type",
-	[BL_ERROR_BAD_MESSAGE_LENGTH] = "Bad message length",
-	[BL_ERROR_BAD_SOURCE_MASK]    = "Bad source mask",
-	[BL_ERROR_ACTIVE_ACQUISITION] = "In acquisition state",
-	[BL_ERROR_BAD_FREQUENCY]      = "Unsupported frequency combination",
-	[BL_ERROR_NOT_IMPLEMENTED]    = "Feature not implemented",
-	[BL_ERROR_HARDWARE_CONFLICT]  = "Hardware conflict",
+	[BL_ERROR_NONE]                = "Success",
+	[BL_ERROR_OUT_OF_RANGE]        = "Value out of range",
+	[BL_ERROR_BAD_MESSAGE_TYPE]    = "Bad message type",
+	[BL_ERROR_BAD_MESSAGE_LENGTH]  = "Bad message length",
+	[BL_ERROR_BAD_SOURCE_MASK]     = "Bad source mask",
+	[BL_ERROR_ACTIVE_ACQUISITION]  = "In acquisition state",
+	[BL_ERROR_BAD_FREQUENCY]       = "Unsupported frequency combination",
+	[BL_ERROR_NOT_IMPLEMENTED]     = "Feature not implemented",
+	[BL_ERROR_HARDWARE_CONFLICT]   = "Hardware conflict",
+	[BL_ERROR_ADC_FREQ_TOO_HIGH]   = "Frequency too high for ADC",
+	[BL_ERROR_ADC_DMA_BUFFER]      = "Config exceeds DMA buffer size",
+	[BL_ERROR_DAC_BAD_CHANNEL]     = "Bad DAC channel",
+	[BL_ERROR_DAC_BAD_OFFSET]      = "Bad DAC offset",
+	[BL_ERROR_OPAMP_BAD_GAIN]      = "Bad opamp gain",
+	[BL_ERROR_TIMER_BAD_FREQUENCY] = "Bad timer frequency",
 };
 
 static inline unsigned bl_msg_str_to_index(


### PR DESCRIPTION
This:

* adds support for new revision 2 hardware source configuration
* splits concepts of channels and sources

For now, channels are the same as sources.  In the future we can make it so there is a channel per LED, and multiple channels share a source, and flash the LEDs appropriately.