### PR TITLE
Terry/spi delay improve

### DIFF
--- a/common/acq.h
+++ b/common/acq.h
@@ -17,11 +17,12 @@
 #ifndef BL_COMMON_ACQ_H
 #define BL_COMMON_ACQ_H
 
-/** SPI mode**/
+/** SPI mode **/
 extern enum bl_acq_spi_mode {
 	BL_ACQ_SPI_NONE,
 	BL_ACQ_SPI_MOTHER,
 	BL_ACQ_SPI_DAUGHTER,
+	BL_ACQ_SPI_INIT,
 } bl_spi_mode;
 
 /** Acquisition detection mode **/

--- a/firmware/src/acq.c
+++ b/firmware/src/acq.c
@@ -123,11 +123,13 @@ enum bl_error bl_acq_start(
 	/* Detection mode casting to SPI mode:
 	 * reflective   -> none SPI
 	 * transmissive -> SPI mother mode
-	 * As USB is connected, SPI daughter mode is not valid
+	 * Changing from SPI mother mode to daughter requires
+	 * reconnecting USB cable, thus power cycle, so this routine
+	 * is not valid in firmware
 	 */
 	if (bl_spi_mode != (enum bl_acq_spi_mode)detection_mode) {
 		bl_spi_mode = detection_mode;
-		if (bl_spi_mode != BL_ACQ_SPI_NONE) {
+		if (bl_spi_mode == BL_ACQ_SPI_MOTHER) {
 			bl_spi_init();
 		}
 	}

--- a/firmware/src/bl.c
+++ b/firmware/src/bl.c
@@ -28,7 +28,7 @@
 #include "delay.h"
 #include "spi.h"
 
-enum bl_acq_spi_mode bl_spi_mode = BL_ACQ_SPI_DAUGHTER;
+enum bl_acq_spi_mode bl_spi_mode = BL_ACQ_SPI_INIT;
 
 #if (BL_REVISION == 1)
 const struct rcc_clock_scale rcc_hse_16mhz_3v3 = {
@@ -78,10 +78,14 @@ int main(void)
 	bl_led_status_set(true);
 
 	while (true) {
-		if (bl_spi_mode == BL_ACQ_SPI_DAUGHTER) {
+		if (bl_spi_mode == BL_ACQ_SPI_INIT) {
 			bl_spi_daughter_poll();
+			bl_usb_poll();
+		} else if (bl_spi_mode == BL_ACQ_SPI_DAUGHTER) {
+			bl_spi_daughter_poll();
+		} else {
+			bl_usb_poll();
 		}
-		bl_usb_poll();
 	}
 }
 #endif

--- a/firmware/src/led.c
+++ b/firmware/src/led.c
@@ -224,11 +224,7 @@ static inline void bl_led__gpio_set(unsigned led)
 	*(volatile uint32_t *)bl_led_channel[led].gpio_bsrr = bl_led_channel[led].gpios;
 }
 
-/* Exported function, documented in led.h
- *
- * set/clear bsrr register can be further optimised by change the active
- * LED order to be grouped by GPIO ports, but we will try this first.
- */
+/* Exported function, documented in led.h */
 enum bl_error bl_led_loop(void)
 {
 	if (bl_spi_mode == BL_ACQ_SPI_NONE) {
@@ -246,4 +242,16 @@ enum bl_error bl_led_loop(void)
 	}
 
 	return BL_ERROR_NONE;
+}
+
+/* Exported function, documented in led.h */
+uint32_t bl_led_get_port(uint8_t led)
+{
+	return led_port[led_table[led].port_idx];
+}
+
+/* Exported function, documented in led.h */
+uint16_t bl_led_get_gpio(uint8_t led)
+{
+	return (1U << led_table[led].pin);
 }

--- a/firmware/src/led.c
+++ b/firmware/src/led.c
@@ -227,6 +227,7 @@ static inline void bl_led__gpio_set(unsigned led)
 /* Exported function, documented in led.h */
 enum bl_error bl_led_loop(void)
 {
+	gpio_set(GPIOB, GPIO12);
 	if (bl_spi_mode == BL_ACQ_SPI_NONE) {
 		bl_led__gpio_clear(bl_led_active);
 	}
@@ -236,7 +237,12 @@ enum bl_error bl_led_loop(void)
 		bl_led_active = 0;
 
 	if (bl_spi_mode == BL_ACQ_SPI_MOTHER) {
-		bl_spi_send(bl_led_channel[bl_led_active].led);
+		unsigned led_to_send = bl_led_active + 1;
+		if (led_to_send >= bl_led_count)
+			led_to_send = 0;
+
+		bl_spi_send(bl_led_channel[led_to_send].led);
+		gpio_clear(GPIOB, GPIO12);
 	} else if (bl_spi_mode == BL_ACQ_SPI_NONE) {
 		bl_led__gpio_set(bl_led_active);
 	}

--- a/firmware/src/led.h
+++ b/firmware/src/led.h
@@ -63,9 +63,25 @@ enum bl_error bl_led_setup(uint16_t led_mask);
 /**
  * Flash enabled LEDs in a fixed sequence.
  *
- * \param[in]  led_mask  Mask of LEDs to enable.
  * \return \ref BL_ERROR_NONE on success, or appropriate error otherwise.
  */
 enum bl_error bl_led_loop(void);
+
+/**
+ * get the corresponding GPIO port for specified LED
+ *
+ * \param[in]   led LED index to be checked
+ * \return \ref GPIO port for specified LED
+ */
+uint32_t bl_led_get_port(uint8_t led);
+
+/**
+ * Get the corresponding GPIO pin number for specified LED
+ *
+ * \param[in]   led LED index to be checked
+ * \return \ref GPIO pin for specified LED
+ */
+uint16_t bl_led_get_gpio(uint8_t led);
+
 
 #endif

--- a/firmware/src/spi.c
+++ b/firmware/src/spi.c
@@ -132,7 +132,8 @@ static void bl_spi__setup(void)
 	spi_send_lsb_first(SPI2);
 	spi_fifo_reception_threshold_8bit(SPI2);
 	SPI_I2SCFGR(SPI2) &= ~SPI_I2SCFGR_I2SMOD;
-	if (bl_spi_mode == BL_ACQ_SPI_DAUGHTER) {
+	if (bl_spi_mode == BL_ACQ_SPI_DAUGHTER ||
+		bl_spi_mode == BL_ACQ_SPI_INIT) {
 		/* Software NSS was used for SPI, and GPIO12 is used
 		 * as generic GPIO to indicate LED flash
 		 */
@@ -141,15 +142,15 @@ static void bl_spi__setup(void)
 
 		spi_set_nss_low(SPI2);
 		spi_set_slave_mode(SPI2);
-		spi_enable(SPI2);
 	} else if (bl_spi_mode == BL_ACQ_SPI_MOTHER) {
 		gpio_mode_setup(GPIOB, GPIO_MODE_OUTPUT,
 						GPIO_PUPD_PULLDOWN, GPIO12);
 
 		spi_set_nss_high(SPI2);
 		spi_set_master_mode(SPI2);
-		spi_enable(SPI2);
 	}
+
+	spi_enable(SPI2);
 }
 
 /* Exported function, documented in spi.h */

--- a/firmware/src/spi.c
+++ b/firmware/src/spi.c
@@ -133,10 +133,19 @@ static void bl_spi__setup(void)
 	spi_fifo_reception_threshold_8bit(SPI2);
 	SPI_I2SCFGR(SPI2) &= ~SPI_I2SCFGR_I2SMOD;
 	if (bl_spi_mode == BL_ACQ_SPI_DAUGHTER) {
+		/* Software NSS was used for SPI, and GPIO12 is used
+		 * as generic GPIO to indicate LED flash
+		 */
+		gpio_mode_setup(GPIOB, GPIO_MODE_INPUT,
+						GPIO_PUPD_PULLDOWN, GPIO12);
+
 		spi_set_nss_low(SPI2);
 		spi_set_slave_mode(SPI2);
 		spi_enable(SPI2);
 	} else if (bl_spi_mode == BL_ACQ_SPI_MOTHER) {
+		gpio_mode_setup(GPIOB, GPIO_MODE_OUTPUT,
+						GPIO_PUPD_PULLDOWN, GPIO12);
+
 		spi_set_nss_high(SPI2);
 		spi_set_master_mode(SPI2);
 		spi_enable(SPI2);

--- a/firmware/src/spi.c
+++ b/firmware/src/spi.c
@@ -219,8 +219,22 @@ uint8_t bl_spi_receive(void)
 /* Exported function, documented in spi.h */
 void bl_spi_daughter_poll(void)
 {
+	static uint32_t gpioport, old_gpioport;
+	static uint16_t gpio, old_gpio;
+	static bool to_next = false;
+
 	if (SPI_SR(SPI2) & SPI_SR_RXNE) {
+		bl_spi_mode = BL_ACQ_SPI_DAUGHTER;
 		uint8_t led = bl_spi_receive();
-		bl_led_set(1U << led);
+		gpioport = bl_led_get_port(led);
+		gpio = bl_led_get_gpio(led);
+		to_next = true;
+	}
+	if (to_next && gpio_get(GPIOB, GPIO12)) {
+		gpio_clear(old_gpioport, old_gpio);
+		gpio_set(gpioport, gpio);
+		old_gpioport = gpioport;
+		old_gpio = gpio;
+		to_next = false;
 	}
 }

--- a/firmware/src/spi.h
+++ b/firmware/src/spi.h
@@ -41,7 +41,7 @@ void bl_spi_init(void);
 
 /**
  * Send 8bits data through SPI
- * \param[in]  let 8bits data to be transferred
+ * \param[in]  led 8bits data to be transferred
  */
 void bl_spi_send(uint8_t led);
 


### PR DESCRIPTION
reduced SPI flash delay from 6-10us to about 200-300ns, whose sampling error could be safely ignored(about 0.2% in worst case)