### PR TITLE
Add a 'version' tool to report the firmware's revision and commit

### DIFF
--- a/common/msg.h
+++ b/common/msg.h
@@ -35,6 +35,11 @@
  */
 #define MSG_SAMPLE_DATA32_MAX 15
 
+/**
+ * Number of 32-bit unsigned integers to store the version in
+ */
+#define COMMIT_SHA_LENGTH 5
+
 /** Message type. */
 enum bl_msg_type {
 	BL_MSG_RESPONSE,
@@ -47,6 +52,8 @@ enum bl_msg_type {
 	BL_MSG_SAMPLE_DATA32,
 	BL_MSG_SOURCE_CAP_REQ,
 	BL_MSG_SOURCE_CAP,
+	BL_MSG_VERSION_REQ,
+	BL_MSG_VERSION,
 
 	BL_MSG__COUNT
 };
@@ -146,6 +153,18 @@ typedef struct {
 	uint8_t opamp_gain[6];
 } bl_msg_source_cap_t;
 
+/** Data for \ref BL_MSG_VERSION_REQ. */
+typedef struct {
+	uint8_t type;    /**< Must be \ref BL_MSG_VERSION_REQ */
+} bl_msg_version_req_t;
+
+/** Data for \ref BL_MSG_VERSION. */
+typedef struct {
+	uint8_t type;                           /**< Must be \ref BL_MSG_VERSION */
+	uint8_t revision;                       /**< The REVISION bloodlight was built with */
+	uint32_t commit_sha[COMMIT_SHA_LENGTH]; /**< The sha of the commit the device was built with */
+} bl_msg_version_t;
+
 /** Message data */
 union bl_msg_data {
 	/** Message type. */
@@ -160,6 +179,8 @@ union bl_msg_data {
 	bl_msg_sample_data_t    sample_data;
 	bl_msg_source_cap_req_t source_cap_req;
 	bl_msg_source_cap_t     source_cap;
+	bl_msg_version_req_t    version_req;
+	bl_msg_version_t        version;
 };
 
 /**
@@ -193,6 +214,8 @@ static inline uint8_t bl_msg_type_to_len(enum bl_msg_type type)
 		[BL_MSG_SAMPLE_DATA32]  = BL_SIZEOF_MSG(sample_data),
 		[BL_MSG_SOURCE_CAP_REQ] = BL_SIZEOF_MSG(source_cap_req),
 		[BL_MSG_SOURCE_CAP]     = BL_SIZEOF_MSG(source_cap),
+		[BL_MSG_VERSION_REQ]    = BL_SIZEOF_MSG(version_req),
+		[BL_MSG_VERSION]        = BL_SIZEOF_MSG(version),
 	};
 
 	if (type >= BL_MSG__COUNT) {

--- a/common/util.h
+++ b/common/util.h
@@ -34,4 +34,12 @@
 #define BL_ARRAY_LEN(_a) \
 	((sizeof(_a)) / (sizeof(*_a)))
 
+#define BL_STATIC_ASSERT(e) \
+{ \
+	enum { \
+		bl_static_assert_check = 1 / (!!(e)) \
+	}; \
+}
+
 #endif
+

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -22,6 +22,7 @@ CFILES = \
 
 REVISION ?= 1
 CFLAGS += -DBL_REVISION=$(REVISION)
+CFLAGS += -DBL_COMMIT_SHA=\"$(shell git rev-parse --verify HEAD)\"
 
 ifeq ($(REVISION),1)
 	DEVICE         = stm32f303CCT6

--- a/host/Makefile
+++ b/host/Makefile
@@ -7,6 +7,10 @@ CFLAGS = -Wall -Wextra -pedantic --std=gnu11 -I..
 CFLAGS += $(shell pkg-config libudev --cflags)
 LDFLAGS += $(shell pkg-config libudev --libs)
 
+REVISION ?= 1
+CFLAGS += -DBL_REVISION=$(REVISION)
+CFLAGS += -DBL_COMMIT_SHA=\"$(shell git rev-parse --verify HEAD)\"
+
 BV_CFLAGS = -Ibloodview/sdl-tk/include
 BV_LDFLAGS = -pthread
 


### PR DESCRIPTION
The firmware will send a "version" message in response to a "version request" message.
The "bl" tool can send version request messages and displays the version response's revision and commit next to the tool's revision and commit.