### PR TITLE
bloodview: graph: Pass legend text and colour into constructor.

### DIFF
--- a/host/bloodview/src/data.c
+++ b/host/bloodview/src/data.c
@@ -613,7 +613,9 @@ bool data_start(bool calibrate, unsigned frequency, unsigned channel_mask)
 		if (data_g.mapping[i] == UINT_MAX) {
 			continue;
 		}
-		if (!graph_create(data_g.mapping[i], frequency, i)) {
+		if (!graph_create(data_g.mapping[i], frequency,
+				main_menu_config_get_channel_name(i),
+				main_menu_config_get_channel_colour(i))) {
 			data_finish();
 			return false;
 		}

--- a/host/bloodview/src/graph.h
+++ b/host/bloodview/src/graph.h
@@ -41,12 +41,16 @@ void graph_fini(void);
 /**
  * Create a graph at given index.
  *
+ * The graph legend text must remain available until \ref graph_fini is called.
+ *
  * \param[in]  idx      Graph index to create.
  * \param[in]  freq     The sampling frequency used for the graph.
- * \param[in]  channel  The graph's acquisition channel.
+ * \param[in]  legend   The graph's legend text.
+ * \param[in]  colour   The graph's render colour.
  * \return true on success, or false on errer.
  */
-bool graph_create(unsigned idx, unsigned freq, uint8_t channel);
+bool graph_create(unsigned idx, unsigned freq,
+		const char *legend, SDL_Color colour);
 
 /**
  * Add a sample to a graph.


### PR DESCRIPTION
This means the graph module doesn't need to know anything about the
acquisition channels, or talk to the main menu.