### PR TITLE
Device config usability enhancements.

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -140,6 +140,20 @@ run: build/bloodview
 			-C bloodview/config \
 			$(BV_ARGS)
 
+# Run variant that load the default conifg for the device
+rund: build/bloodview
+	@sudo $(BLOODVIEW_ENV) build/bloodview -d \
+			-R bloodview/resources \
+			-C bloodview/config \
+			$(BV_ARGS)
+
+# Run variant that reloads the previous config
+runp: build/bloodview
+	@sudo $(BLOODVIEW_ENV) build/bloodview -p \
+			-R bloodview/resources \
+			-C bloodview/config \
+			$(BV_ARGS)
+
 docs:
 	$(MKDIR) build/docs
 	doxygen bloodview/docs/doxygen.conf

--- a/host/bloodview/src/bloodview.c
+++ b/host/bloodview/src/bloodview.c
@@ -130,49 +130,49 @@ static bool bloodview__parse_cli(
 		.path_config    = "config",
 	};
 	enum options {
-		BV_OPTTION_PATH_RESOURCES_DIR = 'R',
-		BV_OPTTION_PATH_DEVICE_PATH   = 'D',
-		BV_OPTTION_PATH_CONFIG_DIR    = 'C',
-		BV_OPTIION_CONFIG_PREVIOUS    = 'p',
-		BV_OPTIION_CONFIG_DEFAULT     = 'd',
-		BV_OPTTION_FILE_CONFIG        = 'c',
-		BV_OPTTION_PATH_FONT          = 'f',
+		BV_OPTION_PATH_RESOURCES_DIR = 'R',
+		BV_OPTION_PATH_DEVICE_PATH   = 'D',
+		BV_OPTION_PATH_CONFIG_DIR    = 'C',
+		BV_OPTION_CONFIG_PREVIOUS    = 'p',
+		BV_OPTION_CONFIG_DEFAULT     = 'd',
+		BV_OPTION_FILE_CONFIG        = 'c',
+		BV_OPTION_PATH_FONT          = 'f',
 
 	};
 	static const char optstr[] = "R:C:pdc:f:D:";
 	static struct option options[] = {
 		{
-			.val = BV_OPTTION_PATH_RESOURCES_DIR,
+			.val = BV_OPTION_PATH_RESOURCES_DIR,
 			.name = "resources-dir",
 			.has_arg = required_argument,
 		},
 		{
-			.val = BV_OPTTION_PATH_DEVICE_PATH,
+			.val = BV_OPTION_PATH_DEVICE_PATH,
 			.name = "device-path",
 			.has_arg = required_argument,
 		},
 		{
-			.val = BV_OPTTION_PATH_CONFIG_DIR,
+			.val = BV_OPTION_PATH_CONFIG_DIR,
 			.name = "config-dir",
 			.has_arg = required_argument,
 		},
 		{
-			.val = BV_OPTIION_CONFIG_PREVIOUS,
+			.val = BV_OPTION_CONFIG_PREVIOUS,
 			.name = "previous-config",
 			.has_arg = no_argument,
 		},
 		{
-			.val = BV_OPTIION_CONFIG_DEFAULT,
+			.val = BV_OPTION_CONFIG_DEFAULT,
 			.name = "default-config",
 			.has_arg = no_argument,
 		},
 		{
-			.val = BV_OPTTION_FILE_CONFIG,
+			.val = BV_OPTION_FILE_CONFIG,
 			.name = "config",
 			.has_arg = required_argument,
 		},
 		{
-			.val = BV_OPTTION_PATH_FONT,
+			.val = BV_OPTION_PATH_FONT,
 			.name = "font",
 			.has_arg = required_argument,
 		},
@@ -195,31 +195,31 @@ static bool bloodview__parse_cli(
 		}
 		enum options option = c;
 		switch (option) {
-		case BV_OPTTION_PATH_RESOURCES_DIR:
+		case BV_OPTION_PATH_RESOURCES_DIR:
 			opt.path_resources = optarg;
 			break;
 
-		case BV_OPTTION_PATH_DEVICE_PATH:
+		case BV_OPTION_PATH_DEVICE_PATH:
 			opt.path_device = optarg;
 			break;
 
-		case BV_OPTTION_PATH_CONFIG_DIR:
+		case BV_OPTION_PATH_CONFIG_DIR:
 			opt.path_config = optarg;
 			break;
 
-		case BV_OPTIION_CONFIG_PREVIOUS:
+		case BV_OPTION_CONFIG_PREVIOUS:
 			opt.config_previous = true;
 			break;
 
-		case BV_OPTIION_CONFIG_DEFAULT:
+		case BV_OPTION_CONFIG_DEFAULT:
 			opt.config_default = true;
 			break;
 
-		case BV_OPTTION_FILE_CONFIG:
+		case BV_OPTION_FILE_CONFIG:
 			opt.file_config = optarg;
 			break;
 
-		case BV_OPTTION_PATH_FONT:
+		case BV_OPTION_PATH_FONT:
 			opt.path_font = optarg;
 			break;
 		}

--- a/host/bloodview/src/bloodview.c
+++ b/host/bloodview/src/bloodview.c
@@ -103,6 +103,7 @@ static void bloodview_device_state_change_cb(
 /** Bloodview commandline options. */
 struct bv_options {
 	const char *path_resources; /**< Directory to load resources from. */
+	const char *path_device;    /**< Path to Bloodlight device. */
 	const char *path_config;    /**< Directory where configs are stored. */
 	const char *file_config;    /**< Config filename to load on startup. */
 	const char *path_font;      /**< Path to font file to use. */
@@ -127,15 +128,21 @@ static bool bloodview__parse_cli(
 	};
 	enum options {
 		BV_OPTTION_PATH_RESOURCES_DIR = 'R',
+		BV_OPTTION_PATH_DEVICE_PATH   = 'D',
 		BV_OPTTION_PATH_CONFIG_DIR    = 'C',
 		BV_OPTTION_FILE_CONFIG        = 'c',
 		BV_OPTTION_PATH_FONT          = 'f',
 	};
-	static const char optstr[] = "R:C:c:f:";
+	static const char optstr[] = "R:C:c:f:D:";
 	static struct option options[] = {
 		{
 			.val = BV_OPTTION_PATH_RESOURCES_DIR,
 			.name = "resources-dir",
+			.has_arg = required_argument,
+		},
+		{
+			.val = BV_OPTTION_PATH_DEVICE_PATH,
+			.name = "device-path",
 			.has_arg = required_argument,
 		},
 		{
@@ -174,6 +181,10 @@ static bool bloodview__parse_cli(
 		switch (option) {
 		case BV_OPTTION_PATH_RESOURCES_DIR:
 			opt.path_resources = optarg;
+			break;
+
+		case BV_OPTTION_PATH_DEVICE_PATH:
+			opt.path_device = optarg;
 			break;
 
 		case BV_OPTTION_PATH_CONFIG_DIR:
@@ -219,7 +230,8 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	if (!device_init(NULL, bloodview_device_state_change_cb, NULL)) {
+	if (!device_init(options.path_device,
+			bloodview_device_state_change_cb, NULL)) {
 		dpp_fini();
 		return EXIT_FAILURE;
 	}

--- a/host/bloodview/src/device.c
+++ b/host/bloodview/src/device.c
@@ -75,6 +75,8 @@ static struct {
 	 */
 	volatile unsigned failed_reads;
 
+	uint8_t revision; /**< Device revision.  Zero means unset. */
+
 	FILE *rec; /**< File for acquisition recordings. */
 } bv_device_g;
 
@@ -451,6 +453,7 @@ static void device__thread_receive_msg(
 			break;
 
 		case BL_MSG_VERSION:
+			bv_device_g.revision = recv_msg.version.revision;
 			bl_msg_yaml_print(stderr, &recv_msg);
 			*sent_type = BL_MSG__COUNT;
 			break;

--- a/host/bloodview/src/device.c
+++ b/host/bloodview/src/device.c
@@ -1090,3 +1090,9 @@ const struct device_source_cap *device_get_source_cap(
 
 	return &device_caps[source];
 }
+
+/* Exported function, documented in device.h */
+unsigned device_get_revision(void)
+{
+	return bv_device_g.revision;
+}

--- a/host/bloodview/src/device.h
+++ b/host/bloodview/src/device.h
@@ -118,4 +118,12 @@ const struct device_source_cap *device_get_source_cap(
  * \return source for the channel.
  */
 enum bl_acq_source device_get_channel_source(uint8_t channel);
+
+/**
+ * Get the hardware revision.
+ *
+ * \return the hardware revision.
+ */
+unsigned device_get_revision(void);
+
 #endif /* BV_DEVICE_H */

--- a/host/bloodview/src/util.c
+++ b/host/bloodview/src/util.c
@@ -77,3 +77,18 @@ char *util_create_path(
 
 	return str;
 }
+
+/**
+ * Get change in time in ms.
+ *
+ * \param[in]  time_start  The start time.
+ * \param[in]  time_check  The time to check the change to.
+ * \return change in time in ms.
+ */
+int64_t util_time_diff_ms(
+		struct timespec *time_start,
+		struct timespec *time_check)
+{
+	return ((time_check->tv_sec  - time_start->tv_sec) * 1000 +
+		(time_check->tv_nsec - time_start->tv_nsec) / 1000000);
+}

--- a/host/bloodview/src/util.h
+++ b/host/bloodview/src/util.h
@@ -24,6 +24,7 @@
 #ifndef BV_UTIL_H
 #define BV_UTIL_H
 
+#include <time.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdint.h>
@@ -142,5 +143,16 @@ char *util_create_path(
 		const char *filename);
 
 static inline uint32_t max_u32(uint32_t x, uint32_t y) { return (x > y ? x : y); }
+
+/**
+ * Get change in time in ms.
+ *
+ * \param[in]  time_start  The start time.
+ * \param[in]  time_check  The time to check the change to.
+ * \return change in time in ms.
+ */
+int64_t util_time_diff_ms(
+		struct timespec *time_start,
+		struct timespec *time_check);
 
 #endif


### PR DESCRIPTION
* Get device revision from the firmware on startup.
* Add CLI flag to load default config for device revision (or `make rund`).
* Add CLI flag to load previously saved config (or `make runp`).
* Allow device path to be specified on commandline (e.g. if you have multiple connected devices).