### PR TITLE
host: tools: bl: Fix specification of device paths.

### DIFF
--- a/host/tools/bl.c
+++ b/host/tools/bl.c
@@ -663,8 +663,8 @@ static bl_cmd_fn bl_cmd_lookup(const char *cmd_name)
 void get_dev(int dev, char *argv[])
 {
 	/* Auto device lookup is handled with a NULL path to bl_device_open() */
-	if (strcmp(argv[dev], "--auto") ||
-	    strcmp(argv[dev], "-a")) {
+	if (strcmp(argv[dev], "--auto") == 0 ||
+	    strcmp(argv[dev], "-a") == 0) {
 		argv[dev] = NULL;
 	}
 }


### PR DESCRIPTION
A bug was causing us to always use device auto-detection.
This made it impossible to control two devices; connections
were only made to the first one found.